### PR TITLE
Fix NOTICE copyright holder name

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 liplus-desktop
-Copyright 2026 Liplus Project
+Copyright 2026 Yoshiharu Uematsu


### PR DESCRIPTION
Refs #7

NOTICE ファイルの著作権者を「Liplus Project」から「Yoshiharu Uematsu」に修正。
issue #7 の制約に記載された著作権者名を正確な個人名に変更する。