### PR TITLE
fix: Windows build and CLI spawn fixes from manual testing

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
 name = "liplus_desktop_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["staticlib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -49,10 +49,23 @@ pub fn spawn_pty(
         .openpty(size)
         .map_err(|e| format!("Failed to open PTY: {e}"))?;
 
-    let mut cmd = CommandBuilder::new(&command);
-    for arg in &args {
-        cmd.arg(arg);
-    }
+    // On Windows, .cmd/.bat scripts (like npm-installed CLIs) cannot be spawned directly.
+    // Wrap them with cmd.exe /C so Windows resolves the command via PATH and PATHEXT.
+    let mut cmd = if cfg!(windows) {
+        let mut c = CommandBuilder::new("cmd.exe");
+        c.arg("/C");
+        c.arg(&command);
+        for arg in &args {
+            c.arg(arg);
+        }
+        c
+    } else {
+        let mut c = CommandBuilder::new(&command);
+        for arg in &args {
+            c.arg(arg);
+        }
+        c
+    };
 
     // Spawn the child process in the PTY
     let child = pair

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,20 @@ async function startProcess(paneId: string) {
       }
     });
 
+    // Enable Ctrl+V paste from clipboard
+    pane.terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+      if (e.type === "keydown" && e.ctrlKey && e.key === "v") {
+        navigator.clipboard.readText().then((text) => {
+          if (pane.ptyId && text) {
+            invoke("write_pty", { id: pane.ptyId, data: text }).catch(() => {});
+          }
+        });
+        return false; // prevent xterm default handling
+      }
+      // Ctrl+C: let xterm handle it (sends SIGINT via PTY)
+      return true;
+    });
+
     // Forward terminal resize to PTY
     pane.terminal.onResize(({ cols, rows }) => {
       if (pane.ptyId) {


### PR DESCRIPTION
## Summary

手動テストで発見した3つのビルド・実行時問題を修正。

- MinGW リンカの "export ordinal too large" エラー: `cdylib` crate-type を削除（Tauri 2 では不要）
- Windows で `.cmd` ファイル（npm グローバルインストールされた CLI）が PTY から直接実行できない問題: `cmd.exe /C` でラップ
- xterm.js ターミナルで Ctrl+V ペーストが効かない問題: `attachCustomKeyEventHandler` でクリップボード読み取りを実装

## Test plan

- [x] Windows ビルド成功
- [x] Claude Code CLI が PTY 経由でインタラクティブに起動（認証・入力・出力すべて動作確認済み）
- [x] Ctrl+V ペースト動作確認

Refs #2

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>