### PR TITLE
Add CI workflow for Tauri Windows build [#3]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-gnu
+
+      - name: Set GNU as default host
+        run: rustup set default-host x86_64-pc-windows-gnu
+
+      - run: npm ci
+
+      - name: Build Tauri app
+        run: npm run tauri build
+
+  # Gate job: single Required status check for branch protection.
+  # Add new jobs to `needs` when CI grows. No Settings change needed.
+  CI:
+    if: always()
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ needs.build.result }}" != "success" ]]; then
+            echo "CI failed: build=${{ needs.build.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
Refs #3

Windows ランナー上で Tauri アプリのビルドを自動検証する CI ワークフローを追加する。

## 変更内容

- `.github/workflows/ci.yml` を新規作成
  - トリガー: `main` への push / PR
  - ランナー: `windows-latest`
  - Rust ツールチェーン: stable + `x86_64-pc-windows-gnu` (MinGW)
  - `rustup set default-host x86_64-pc-windows-gnu` でデフォルトホストを GNU に設定
  - `npm ci` → `npm run tauri build` の順で実行
  - ゲートジョブ (`CI`) を設置し、ブランチ保護の Required status check を単一化

## スコープ外

- リリース (CD) は v0.1.0 スコープ外。CI のみ。