### PR TITLE
feat: add agent status badges and button state management

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <div class="pane" id="pane-left">
           <div class="pane-header">
             <span class="pane-label">Claude Code</span>
+            <span class="status-badge status-stopped" id="status-left">Stopped</span>
             <button class="pane-btn" data-action="start" data-pane="left">Start</button>
             <button class="pane-btn" data-action="stop" data-pane="left">Stop</button>
             <button class="pane-btn pane-settings-btn" data-action="settings" data-pane="left">⚙</button>
@@ -26,6 +27,7 @@
         <div class="pane" id="pane-right">
           <div class="pane-header">
             <span class="pane-label">Codex</span>
+            <span class="status-badge status-stopped" id="status-right">Stopped</span>
             <button class="pane-btn" data-action="start" data-pane="right">Start</button>
             <button class="pane-btn" data-action="stop" data-pane="right">Stop</button>
             <button class="pane-btn pane-settings-btn" data-action="settings" data-pane="right">⚙</button>

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -95,6 +95,7 @@ pub fn spawn_pty(
     let app_clone = app.clone();
 
     // Spawn background thread to read PTY output and emit events
+    let ptys_clone = Arc::clone(&state.ptys);
     std::thread::spawn(move || {
         let mut buf = [0u8; 4096];
         loop {
@@ -107,8 +108,17 @@ pub fn spawn_pty(
                 Err(_) => break,
             }
         }
-        // Emit exit event when reader closes
-        let _ = app_clone.emit(&format!("pty-exit-{}", id_clone), ());
+        // Collect exit code before emitting exit event
+        let exit_code: Option<u32> = {
+            let mut map = ptys_clone.lock();
+            if let Some(pty) = map.get_mut(&id_clone) {
+                pty.child.wait().ok().map(|status| status.exit_code())
+            } else {
+                None
+            }
+        };
+        // Emit exit event with exit code payload (None if killed by signal/unknown)
+        let _ = app_clone.emit(&format!("pty-exit-{}", id_clone), exit_code);
     });
 
     state.ptys.lock().insert(

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,21 @@ interface PaneState {
 
 const panes: Record<string, PaneState> = {};
 
+type AgentStatus = "stopped" | "running" | "error";
+
+function setStatus(paneId: string, status: AgentStatus) {
+  const badge = document.getElementById(`status-${paneId}`);
+  if (!badge) return;
+  badge.className = `status-badge status-${status}`;
+  badge.textContent = status.charAt(0).toUpperCase() + status.slice(1);
+
+  // Update button disabled states
+  const startBtn = document.querySelector(`.pane-btn[data-action="start"][data-pane="${paneId}"]`) as HTMLButtonElement | null;
+  const stopBtn = document.querySelector(`.pane-btn[data-action="stop"][data-pane="${paneId}"]`) as HTMLButtonElement | null;
+  if (startBtn) startBtn.disabled = status === "running";
+  if (stopBtn) stopBtn.disabled = status !== "running";
+}
+
 // Currently open settings modal target
 let settingsTargetPane: string | null = null;
 
@@ -75,15 +90,23 @@ async function startProcess(paneId: string) {
     });
 
     pane.ptyId = id;
+    setStatus(paneId, "running");
 
     // Listen for PTY output
     pane.unlistenData = await listen<string>(`pty-data-${id}`, (event) => {
       pane.terminal.write(event.payload);
     });
 
-    // Listen for PTY exit
-    pane.unlistenExit = await listen<null>(`pty-exit-${id}`, () => {
-      pane.terminal.writeln("\r\n\x1b[33m[Process exited]\x1b[0m");
+    // Listen for PTY exit (payload is exit code or null)
+    pane.unlistenExit = await listen<number | null>(`pty-exit-${id}`, (event) => {
+      const code = event.payload;
+      if (code !== null && code !== 0) {
+        pane.terminal.writeln(`\r\n\x1b[31m[Exited with code ${code}]\x1b[0m`);
+        setStatus(paneId, "error");
+      } else {
+        pane.terminal.writeln("\r\n\x1b[33m[Process exited]\x1b[0m");
+        setStatus(paneId, "stopped");
+      }
       cleanupPane(paneId);
     });
 
@@ -116,6 +139,7 @@ async function startProcess(paneId: string) {
     });
   } catch (e) {
     pane.terminal.writeln(`\r\n\x1b[31m[Failed to start: ${e}]\x1b[0m`);
+    setStatus(paneId, "error");
   }
 }
 
@@ -140,6 +164,7 @@ async function stopProcess(paneId: string) {
   try {
     await invoke("kill_pty", { id });
     pane.terminal.writeln("\r\n\x1b[33m[Stopped]\x1b[0m");
+    setStatus(paneId, "stopped");
   } catch (e) {
     pane.terminal.writeln(`\r\n\x1b[31m[Stop failed: ${e}]\x1b[0m`);
   }
@@ -261,6 +286,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   panes["right"].terminal.writeln("\x1b[36mLi+ Desktop — Codex pane\x1b[0m");
   panes["right"].terminal.writeln("Press \x1b[32mStart\x1b[0m to launch Codex CLI.\r\n");
+
+  // Set initial button states
+  setStatus("left", "stopped");
+  setStatus("right", "stopped");
 
   // Pane button handlers
   document.querySelectorAll(".pane-btn").forEach((btn) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -98,6 +98,45 @@
   height: 100%;
 }
 
+/* Status badge */
+.status-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 8px;
+  letter-spacing: 0.03em;
+  user-select: none;
+}
+
+.status-stopped {
+  background: #2a2a3a;
+  color: #6b7280;
+  border: 1px solid #3a3a4a;
+}
+
+.status-running {
+  background: #0d2b1a;
+  color: #34d399;
+  border: 1px solid #065f46;
+}
+
+.status-error {
+  background: #2b0d0d;
+  color: #f87171;
+  border: 1px solid #7f1d1d;
+}
+
+/* Disabled button state */
+.pane-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.pane-btn:disabled:hover {
+  background: #1a1a2e;
+  color: #a8b2d1;
+}
+
 /* Settings button */
 .pane-settings-btn {
   padding: 2px 7px;


### PR DESCRIPTION
## Summary

- 各ペインヘッダーに状態バッジ追加（Stopped / Running / Error）
- Start ボタン: Running 中は無効化、Stop ボタン: Stopped 中は無効化
- プロセス異常終了時に終了コードを表示 + Error 状態に遷移
- PTY reader スレッドから exit code を emit するように変更

Refs #15

## Test plan

- [ ] Start → Running バッジ表示、Start ボタン無効化を確認
- [ ] Stop → Stopped バッジ表示、Stop ボタン無効化を確認
- [ ] 存在しないコマンドを設定 → Error バッジ表示を確認