### PR TITLE
feat: add stream-json NDJSON parser and unified ChatMessage type

### DIFF
--- a/src-tauri/src/chat_message.rs
+++ b/src-tauri/src/chat_message.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+/// Content type classification for unified chat messages.
+/// Maps CLI-specific message subtypes to a common taxonomy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentType {
+    Text,
+    Thinking,
+    ToolUse,
+    ToolResult,
+    Status,
+}
+
+/// Role of the message sender in the conversation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    System,
+    Assistant,
+    User,
+}
+
+/// Unified chat message type emitted to the frontend via Tauri events.
+/// All CLI-specific message formats are normalized into this structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: Role,
+    pub content_type: ContentType,
+    pub body: String,
+    /// Optional metadata from the original CLI message (preserved as raw JSON).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -47,21 +47,18 @@ pub fn load_config(app: AppHandle) -> Result<AppConfig, String> {
     if !path.exists() {
         return Ok(AppConfig::default());
     }
-    let content = std::fs::read_to_string(&path)
-        .map_err(|e| format!("Failed to read config: {e}"))?;
-    serde_json::from_str(&content)
-        .map_err(|e| format!("Failed to parse config: {e}"))
+    let content =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read config: {e}"))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse config: {e}"))
 }
 
 #[tauri::command]
 pub fn save_config(app: AppHandle, config: AppConfig) -> Result<(), String> {
     let path = config_path(&app)?;
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create config dir: {e}"))?;
+        std::fs::create_dir_all(parent).map_err(|e| format!("Failed to create config dir: {e}"))?;
     }
     let content = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config: {e}"))?;
-    std::fs::write(&path, content)
-        .map_err(|e| format!("Failed to write config: {e}"))
+    std::fs::write(&path, content).map_err(|e| format!("Failed to write config: {e}"))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
+mod chat_message;
 mod config;
 mod pty;
+mod stream_parser;
 
 use pty::PtyState;
 
@@ -10,6 +12,7 @@ pub fn run() {
         .manage(PtyState::new())
         .invoke_handler(tauri::generate_handler![
             pty::spawn_pty,
+            pty::spawn_stream_pty,
             pty::write_pty,
             pty::resize_pty,
             pty::kill_pty,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,10 +1,12 @@
-use std::collections::HashMap;
-use std::io::{Read, Write};
-use std::sync::Arc;
 use parking_lot::Mutex;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
+
+use crate::stream_parser::{self, CliKind};
 
 struct PtyInstance {
     writer: Box<dyn Write + Send>,
@@ -134,11 +136,7 @@ pub fn spawn_pty(
 }
 
 #[tauri::command]
-pub fn write_pty(
-    state: tauri::State<PtyState>,
-    id: String,
-    data: String,
-) -> Result<(), String> {
+pub fn write_pty(state: tauri::State<PtyState>, id: String, data: String) -> Result<(), String> {
     let mut map = state.ptys.lock();
     let pty = map
         .get_mut(&id)
@@ -170,15 +168,142 @@ pub fn resize_pty(
 }
 
 #[tauri::command]
-pub fn kill_pty(
-    state: tauri::State<PtyState>,
-    id: String,
-) -> Result<(), String> {
+pub fn kill_pty(state: tauri::State<PtyState>, id: String) -> Result<(), String> {
     let mut map = state.ptys.lock();
     if let Some(mut pty) = map.remove(&id) {
-        pty.child
-            .kill()
-            .map_err(|e| format!("Kill failed: {e}"))?;
+        pty.child.kill().map_err(|e| format!("Kill failed: {e}"))?;
     }
     Ok(())
+}
+
+/// Spawn a CLI process in stream-json mode.
+///
+/// Instead of forwarding raw PTY bytes, this command:
+/// 1. Reads stdout line-by-line
+/// 2. Parses each line as NDJSON
+/// 3. Converts to a unified ChatMessage via the CLI-specific converter
+/// 4. Emits `chat-message-{id}` Tauri events to the frontend
+///
+/// The `cli_kind` parameter selects the converter: "claude" or "codex".
+/// Lines that fail JSON parsing are silently dropped (ANSI noise tolerance).
+#[tauri::command]
+pub fn spawn_stream_pty(
+    app: AppHandle,
+    state: tauri::State<PtyState>,
+    command: String,
+    args: Vec<String>,
+    cols: u16,
+    rows: u16,
+    cwd: Option<String>,
+    cli_kind: String,
+) -> Result<String, String> {
+    let kind = match cli_kind.as_str() {
+        "claude" => CliKind::ClaudeCode,
+        "codex" => CliKind::Codex,
+        other => {
+            return Err(format!(
+                "Unknown cli_kind: {other}. Expected 'claude' or 'codex'."
+            ))
+        }
+    };
+
+    let pty_system = NativePtySystem::default();
+
+    let size = PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    };
+
+    let pair = pty_system
+        .openpty(size)
+        .map_err(|e| format!("Failed to open PTY: {e}"))?;
+
+    let mut cmd = if cfg!(windows) {
+        let mut c = CommandBuilder::new("cmd.exe");
+        c.arg("/C");
+        c.arg(&command);
+        for arg in &args {
+            c.arg(arg);
+        }
+        c
+    } else {
+        let mut c = CommandBuilder::new(&command);
+        for arg in &args {
+            c.arg(arg);
+        }
+        c
+    };
+
+    if let Some(dir) = cwd {
+        cmd.cwd(dir);
+    }
+
+    let child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("Failed to spawn '{command}': {e}"))?;
+
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| format!("Failed to get PTY writer: {e}"))?;
+
+    let reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|e| format!("Failed to get PTY reader: {e}"))?;
+
+    let id = Uuid::new_v4().to_string();
+    let id_clone = id.clone();
+    let app_clone = app.clone();
+
+    // Spawn background thread: line-buffered NDJSON parser
+    let ptys_clone = Arc::clone(&state.ptys);
+    std::thread::spawn(move || {
+        let buf_reader = BufReader::new(reader);
+        for line in buf_reader.lines() {
+            match line {
+                Ok(text) => {
+                    if let Some(value) = stream_parser::parse_ndjson_line(&text) {
+                        // Convert all blocks (handles multi-block messages)
+                        let messages = stream_parser::convert_claude_all(&value);
+                        if !messages.is_empty() && kind == CliKind::ClaudeCode {
+                            for msg in messages {
+                                let _ = app_clone.emit(&format!("chat-message-{}", id_clone), &msg);
+                            }
+                        } else if let Some(msg) = stream_parser::convert(kind, &value) {
+                            let _ = app_clone.emit(&format!("chat-message-{}", id_clone), &msg);
+                        }
+                        // Also emit the raw JSON for debugging / advanced consumers
+                        let _ = app_clone.emit(&format!("stream-raw-{}", id_clone), &value);
+                    }
+                    // Non-JSON lines are silently dropped (ANSI noise, etc.)
+                }
+                Err(_) => break,
+            }
+        }
+        // Collect exit code
+        let exit_code: Option<u32> = {
+            let mut map = ptys_clone.lock();
+            if let Some(pty) = map.get_mut(&id_clone) {
+                pty.child.wait().ok().map(|status| status.exit_code())
+            } else {
+                None
+            }
+        };
+        let _ = app_clone.emit(&format!("pty-exit-{}", id_clone), exit_code);
+    });
+
+    state.ptys.lock().insert(
+        id.clone(),
+        PtyInstance {
+            writer,
+            child,
+            killer: pair.master,
+        },
+    );
+
+    Ok(id)
 }

--- a/src-tauri/src/stream_parser.rs
+++ b/src-tauri/src/stream_parser.rs
@@ -1,0 +1,493 @@
+use crate::chat_message::{ChatMessage, ContentType, Role};
+use serde_json::Value;
+
+/// Identifies which CLI produced the NDJSON stream.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CliKind {
+    ClaudeCode,
+    Codex,
+}
+
+// ---------------------------------------------------------------------------
+// Common layer: NDJSON line parser
+// ---------------------------------------------------------------------------
+
+/// Parse a single line of NDJSON into a serde_json::Value.
+/// Returns None for blank lines or lines that fail to parse (e.g. ANSI noise).
+pub fn parse_ndjson_line(line: &str) -> Option<Value> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    serde_json::from_str(trimmed).ok()
+}
+
+// ---------------------------------------------------------------------------
+// CLI-specific conversion layer
+// ---------------------------------------------------------------------------
+
+/// Convert a raw JSON value into a unified ChatMessage using the appropriate
+/// CLI-specific converter. Returns None when the message type is unknown or
+/// should be silently dropped (e.g. internal bookkeeping events).
+pub fn convert(kind: CliKind, value: &Value) -> Option<ChatMessage> {
+    match kind {
+        CliKind::ClaudeCode => convert_claude(value),
+        CliKind::Codex => convert_codex(value),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code converter
+// ---------------------------------------------------------------------------
+//
+// Known message types from `claude --print --output-format stream-json --verbose`:
+//   { "type": "system",  "subtype": "init", ... }
+//   { "type": "assistant", "message": { "content": [ { "type": "thinking"|"text"|"tool_use", ... } ] } }
+//   { "type": "user",     "message": { "content": [ { "type": "tool_result", ... } ] } }
+//   { "type": "result",   "subtype": "success", "result": "..." }
+
+fn convert_claude(v: &Value) -> Option<ChatMessage> {
+    let msg_type = v.get("type")?.as_str()?;
+
+    match msg_type {
+        // --- system (init, etc.) ---
+        "system" => {
+            let subtype = v.get("subtype").and_then(|s| s.as_str()).unwrap_or("");
+            let body = match subtype {
+                "init" => format!(
+                    "Session initialized: {}",
+                    v.get("session_id")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("unknown")
+                ),
+                _ => format!("system:{subtype}"),
+            };
+            Some(ChatMessage {
+                role: Role::System,
+                content_type: ContentType::Status,
+                body,
+                metadata: Some(v.clone()),
+            })
+        }
+
+        // --- assistant turn ---
+        "assistant" => {
+            let content = v
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())?;
+
+            // Flatten all content blocks into one ChatMessage per block.
+            // We return the first meaningful block; the caller can invoke
+            // convert_claude_all() if it needs every block.
+            for block in content {
+                let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                match block_type {
+                    "thinking" => {
+                        let text = block.get("thinking").and_then(|t| t.as_str()).unwrap_or("");
+                        if !text.is_empty() {
+                            return Some(ChatMessage {
+                                role: Role::Assistant,
+                                content_type: ContentType::Thinking,
+                                body: text.to_string(),
+                                metadata: Some(block.clone()),
+                            });
+                        }
+                    }
+                    "text" => {
+                        let text = block.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                        if !text.is_empty() {
+                            return Some(ChatMessage {
+                                role: Role::Assistant,
+                                content_type: ContentType::Text,
+                                body: text.to_string(),
+                                metadata: None,
+                            });
+                        }
+                    }
+                    "tool_use" => {
+                        let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
+                        let input = block
+                            .get("input")
+                            .map(|i| i.to_string())
+                            .unwrap_or_default();
+                        return Some(ChatMessage {
+                            role: Role::Assistant,
+                            content_type: ContentType::ToolUse,
+                            body: format!("{name}: {input}"),
+                            metadata: Some(block.clone()),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            None
+        }
+
+        // --- user turn (tool_result) ---
+        "user" => {
+            let content = v
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())?;
+
+            for block in content {
+                let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                if block_type == "tool_result" {
+                    let output = block
+                        .get("content")
+                        .and_then(|c| {
+                            if let Some(s) = c.as_str() {
+                                Some(s.to_string())
+                            } else if let Some(arr) = c.as_array() {
+                                // content can be array of { type: "text", text: "..." }
+                                let texts: Vec<&str> = arr
+                                    .iter()
+                                    .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+                                    .collect();
+                                if texts.is_empty() {
+                                    None
+                                } else {
+                                    Some(texts.join("\n"))
+                                }
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or_default();
+                    return Some(ChatMessage {
+                        role: Role::User,
+                        content_type: ContentType::ToolResult,
+                        body: output,
+                        metadata: Some(block.clone()),
+                    });
+                }
+            }
+            None
+        }
+
+        // --- result ---
+        "result" => {
+            let result_text = v
+                .get("result")
+                .and_then(|r| r.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(ChatMessage {
+                role: Role::Assistant,
+                content_type: ContentType::Text,
+                body: result_text,
+                metadata: Some(v.clone()),
+            })
+        }
+
+        // --- rate_limit_event ---
+        "rate_limit_event" => Some(ChatMessage {
+            role: Role::System,
+            content_type: ContentType::Status,
+            body: "Rate limit reached — waiting".to_string(),
+            metadata: Some(v.clone()),
+        }),
+
+        _ => None,
+    }
+}
+
+/// Convert a single Claude Code JSON value into *all* ChatMessages it contains
+/// (one per content block). Useful for messages with multiple blocks.
+pub fn convert_claude_all(v: &Value) -> Vec<ChatMessage> {
+    let msg_type = match v.get("type").and_then(|t| t.as_str()) {
+        Some(t) => t,
+        None => return vec![],
+    };
+
+    match msg_type {
+        "assistant" | "user" => {
+            let content = match v
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())
+            {
+                Some(c) => c,
+                None => return vec![],
+            };
+
+            let role = if msg_type == "assistant" {
+                Role::Assistant
+            } else {
+                Role::User
+            };
+
+            content
+                .iter()
+                .filter_map(|block| {
+                    let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    match block_type {
+                        "thinking" => {
+                            let text = block.get("thinking").and_then(|t| t.as_str()).unwrap_or("");
+                            if text.is_empty() {
+                                return None;
+                            }
+                            Some(ChatMessage {
+                                role: role.clone(),
+                                content_type: ContentType::Thinking,
+                                body: text.to_string(),
+                                metadata: Some(block.clone()),
+                            })
+                        }
+                        "text" => {
+                            let text = block.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                            if text.is_empty() {
+                                return None;
+                            }
+                            Some(ChatMessage {
+                                role: role.clone(),
+                                content_type: ContentType::Text,
+                                body: text.to_string(),
+                                metadata: None,
+                            })
+                        }
+                        "tool_use" => {
+                            let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
+                            let input = block
+                                .get("input")
+                                .map(|i| i.to_string())
+                                .unwrap_or_default();
+                            Some(ChatMessage {
+                                role: role.clone(),
+                                content_type: ContentType::ToolUse,
+                                body: format!("{name}: {input}"),
+                                metadata: Some(block.clone()),
+                            })
+                        }
+                        "tool_result" => {
+                            let output = block
+                                .get("content")
+                                .and_then(|c| c.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            Some(ChatMessage {
+                                role: role.clone(),
+                                content_type: ContentType::ToolResult,
+                                body: output,
+                                metadata: Some(block.clone()),
+                            })
+                        }
+                        _ => None,
+                    }
+                })
+                .collect()
+        }
+        _ => {
+            // For non-multi-block types, delegate to single converter
+            convert_claude(v).into_iter().collect()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Codex CLI converter
+// ---------------------------------------------------------------------------
+//
+// Known message types from `codex exec --json`:
+//   { "type": "thread.started", ... }
+//   { "type": "turn.started",   ... }
+//   { "type": "turn.completed", ... }
+//   { "type": "item.started",   "item": { "type": "agent_message"|"command_execution"|"reasoning", ... } }
+//   { "type": "item.completed", "item": { "type": "agent_message"|"command_execution"|"reasoning", ... } }
+
+fn convert_codex(v: &Value) -> Option<ChatMessage> {
+    let msg_type = v.get("type")?.as_str()?;
+
+    match msg_type {
+        "thread.started" => Some(ChatMessage {
+            role: Role::System,
+            content_type: ContentType::Status,
+            body: "Thread started".to_string(),
+            metadata: Some(v.clone()),
+        }),
+
+        "turn.started" => Some(ChatMessage {
+            role: Role::System,
+            content_type: ContentType::Status,
+            body: "Turn started".to_string(),
+            metadata: Some(v.clone()),
+        }),
+
+        "turn.completed" => Some(ChatMessage {
+            role: Role::System,
+            content_type: ContentType::Status,
+            body: "Turn completed".to_string(),
+            metadata: Some(v.clone()),
+        }),
+
+        "item.started" | "item.completed" => {
+            let item = v.get("item")?;
+            let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+            match item_type {
+                "agent_message" => {
+                    // Extract text from content array or content string
+                    let body = extract_codex_text(item);
+                    if body.is_empty() {
+                        return None;
+                    }
+                    Some(ChatMessage {
+                        role: Role::Assistant,
+                        content_type: ContentType::Text,
+                        body,
+                        metadata: Some(item.clone()),
+                    })
+                }
+                "command_execution" => {
+                    let command = item.get("command").and_then(|c| c.as_str()).unwrap_or("");
+                    let output = item.get("output").and_then(|o| o.as_str()).unwrap_or("");
+                    let body = if output.is_empty() {
+                        format!("$ {command}")
+                    } else {
+                        format!("$ {command}\n{output}")
+                    };
+                    // command_execution maps to tool_use (started) or tool_result (completed)
+                    let content_type = if msg_type == "item.started" {
+                        ContentType::ToolUse
+                    } else {
+                        ContentType::ToolResult
+                    };
+                    Some(ChatMessage {
+                        role: if msg_type == "item.started" {
+                            Role::Assistant
+                        } else {
+                            Role::User
+                        },
+                        content_type,
+                        body,
+                        metadata: Some(item.clone()),
+                    })
+                }
+                "reasoning" => {
+                    let text = extract_codex_text(item);
+                    if text.is_empty() {
+                        return None;
+                    }
+                    Some(ChatMessage {
+                        role: Role::Assistant,
+                        content_type: ContentType::Thinking,
+                        body: text,
+                        metadata: Some(item.clone()),
+                    })
+                }
+                _ => None,
+            }
+        }
+
+        _ => None,
+    }
+}
+
+/// Extract text from a Codex item's content field.
+/// Content can be a string or an array of { type: "text", text: "..." } objects.
+fn extract_codex_text(item: &Value) -> String {
+    if let Some(content) = item.get("content") {
+        if let Some(s) = content.as_str() {
+            return s.to_string();
+        }
+        if let Some(arr) = content.as_array() {
+            let texts: Vec<&str> = arr
+                .iter()
+                .filter_map(|block| block.get("text").and_then(|t| t.as_str()))
+                .collect();
+            return texts.join("\n");
+        }
+    }
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_ndjson() {
+        let line = r#"{"type":"system","subtype":"init","session_id":"abc123"}"#;
+        let val = parse_ndjson_line(line);
+        assert!(val.is_some());
+        assert_eq!(val.unwrap()["type"], "system");
+    }
+
+    #[test]
+    fn parse_blank_line() {
+        assert!(parse_ndjson_line("").is_none());
+        assert!(parse_ndjson_line("   ").is_none());
+    }
+
+    #[test]
+    fn parse_invalid_json() {
+        assert!(parse_ndjson_line("not json at all").is_none());
+        assert!(parse_ndjson_line("\x1b[0msome ansi").is_none());
+    }
+
+    #[test]
+    fn claude_system_init() {
+        let v: Value =
+            serde_json::from_str(r#"{"type":"system","subtype":"init","session_id":"sess-42"}"#)
+                .unwrap();
+        let msg = convert(CliKind::ClaudeCode, &v).unwrap();
+        assert_eq!(msg.role, Role::System);
+        assert_eq!(msg.content_type, ContentType::Status);
+        assert!(msg.body.contains("sess-42"));
+    }
+
+    #[test]
+    fn claude_assistant_text() {
+        let v: Value = serde_json::from_str(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello world"}]}}"#,
+        )
+        .unwrap();
+        let msg = convert(CliKind::ClaudeCode, &v).unwrap();
+        assert_eq!(msg.role, Role::Assistant);
+        assert_eq!(msg.content_type, ContentType::Text);
+        assert_eq!(msg.body, "Hello world");
+    }
+
+    #[test]
+    fn claude_result() {
+        let v: Value =
+            serde_json::from_str(r#"{"type":"result","subtype":"success","result":"Done!"}"#)
+                .unwrap();
+        let msg = convert(CliKind::ClaudeCode, &v).unwrap();
+        assert_eq!(msg.role, Role::Assistant);
+        assert_eq!(msg.body, "Done!");
+    }
+
+    #[test]
+    fn codex_thread_started() {
+        let v: Value = serde_json::from_str(r#"{"type":"thread.started"}"#).unwrap();
+        let msg = convert(CliKind::Codex, &v).unwrap();
+        assert_eq!(msg.role, Role::System);
+        assert_eq!(msg.content_type, ContentType::Status);
+    }
+
+    #[test]
+    fn codex_agent_message() {
+        let v: Value = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"type":"agent_message","content":"Response text"}}"#,
+        )
+        .unwrap();
+        let msg = convert(CliKind::Codex, &v).unwrap();
+        assert_eq!(msg.role, Role::Assistant);
+        assert_eq!(msg.content_type, ContentType::Text);
+        assert_eq!(msg.body, "Response text");
+    }
+
+    #[test]
+    fn codex_command_execution() {
+        let v: Value = serde_json::from_str(
+            r#"{"type":"item.started","item":{"type":"command_execution","command":"ls -la","output":""}}"#,
+        )
+        .unwrap();
+        let msg = convert(CliKind::Codex, &v).unwrap();
+        assert_eq!(msg.role, Role::Assistant);
+        assert_eq!(msg.content_type, ContentType::ToolUse);
+        assert!(msg.body.contains("ls -la"));
+    }
+}


### PR DESCRIPTION
Refs #21

CLIのstream-json出力をRust側でパースし、CLI種別に依存しない統一ChatMessage型に正規化する2層アーキテクチャを実装。

- 共通NDJSON行パーサー層: 1行1JSONオブジェクトを行単位で読み取り、パース失敗行は無視(ANSIエスケープ混入への耐性)
- CLI別変換層: Claude Code / Codex CLIのメッセージ型を統一ChatMessage型(role + content_type + body + metadata)に正規化
- spawn_stream_ptyコマンド: 既存のraw PTYモードを維持しつつ、stream-jsonモード用の新しいspawnコマンドを追加
- chat-message-{id} Tauriイベントで統一型をフロントエンドに送出、stream-raw-{id}で生JSONも併送