### PR TITLE
feat(ui): replace xterm.js terminal with chat bubble UI [#22]

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             <button class="pane-btn" data-action="stop" data-pane="left">Stop</button>
             <button class="pane-btn pane-settings-btn" data-action="settings" data-pane="left">⚙</button>
           </div>
-          <div class="terminal-container" id="terminal-left"></div>
+          <div class="chat-container" id="chat-left"></div>
         </div>
         <div id="divider"></div>
         <div class="pane" id="pane-right">
@@ -32,7 +32,7 @@
             <button class="pane-btn" data-action="stop" data-pane="right">Stop</button>
             <button class="pane-btn pane-settings-btn" data-action="settings" data-pane="right">⚙</button>
           </div>
-          <div class="terminal-container" id="terminal-right"></div>
+          <div class="chat-container" id="chat-right"></div>
         </div>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,13 @@
     "": {
       "name": "liplus-desktop",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
-        "@tauri-apps/plugin-shell": "^2.3.5",
-        "@xterm/addon-fit": "^0.11.0",
-        "@xterm/xterm": "^6.0.0"
+        "highlight.js": "^11.11.1",
+        "marked": "^15.0.7",
+        "marked-highlight": "^2.2.1"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -1102,36 +1103,12 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
-    "node_modules/@tauri-apps/plugin-shell": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
-      "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@xterm/addon-fit": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
-      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
-      "license": "MIT"
-    },
-    "node_modules/@xterm/xterm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
-      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
-      "license": "MIT",
-      "workspaces": [
-        "addons/*"
-      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1206,6 +1183,36 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-highlight": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.3.tgz",
+      "integrity": "sha512-FCfZRxW/msZAiasCML4isYpxyQWKEEx44vOgdn5Kloae+Qc3q4XR7WjpKKf8oMLk7JP9ZCRd2vhtclJFdwxlWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=4 <18"
       }
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
-    "@tauri-apps/plugin-shell": "^2.3.5",
-    "@xterm/addon-fit": "^0.11.0",
-    "@xterm/xterm": "^6.0.0"
+    "highlight.js": "^11.11.1",
+    "marked": "^15.0.7",
+    "marked-highlight": "^2.2.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1,0 +1,350 @@
+import { renderMarkdown } from "./markdown";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, UnlistenFn } from "@tauri-apps/api/event";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors Rust ChatMessage / ContentType / Role
+// ---------------------------------------------------------------------------
+
+type ContentType = "text" | "thinking" | "tool_use" | "tool_result" | "status";
+type Role = "system" | "assistant" | "user";
+
+interface ChatMessage {
+  role: Role;
+  content_type: ContentType;
+  body: string;
+  metadata?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// ChatPane — one chat UI instance (left or right pane)
+// ---------------------------------------------------------------------------
+
+export class ChatPane {
+  private container: HTMLElement;
+  private messagesEl: HTMLElement;
+  private textareaEl: HTMLTextAreaElement;
+  private sendBtn: HTMLButtonElement;
+  private ptyId: string | null = null;
+  private unlistenChat: UnlistenFn | null = null;
+  private unlistenExit: UnlistenFn | null = null;
+  /** Whether user has scrolled up (disables auto-scroll) */
+  private userScrolled = false;
+  /** Element for the currently streaming assistant message (appended incrementally) */
+  private streamingBubble: HTMLElement | null = null;
+  /** Accumulated body text for the current streaming message */
+  private streamingBody = "";
+  /** Content type of the current streaming message */
+  private streamingType: ContentType | null = null;
+
+  constructor(containerId: string) {
+    this.container = document.getElementById(containerId)!;
+
+    // Build DOM structure
+    this.messagesEl = document.createElement("div");
+    this.messagesEl.className = "chat-messages";
+
+    const inputArea = document.createElement("div");
+    inputArea.className = "chat-input-area";
+
+    this.textareaEl = document.createElement("textarea");
+    this.textareaEl.className = "chat-textarea";
+    this.textareaEl.placeholder = "Type a message...";
+    this.textareaEl.rows = 1;
+
+    this.sendBtn = document.createElement("button");
+    this.sendBtn.className = "chat-send-btn";
+    this.sendBtn.textContent = "Send";
+    this.sendBtn.disabled = true;
+
+    inputArea.appendChild(this.textareaEl);
+    inputArea.appendChild(this.sendBtn);
+
+    this.container.appendChild(this.messagesEl);
+    this.container.appendChild(inputArea);
+
+    // --- Event listeners ---
+
+    // Auto-scroll detection
+    this.messagesEl.addEventListener("scroll", () => {
+      const el = this.messagesEl;
+      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+      this.userScrolled = !atBottom;
+    });
+
+    // Enter to send, Shift+Enter for newline
+    this.textareaEl.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        this.sendMessage();
+      }
+    });
+
+    // Auto-resize textarea
+    this.textareaEl.addEventListener("input", () => {
+      this.textareaEl.style.height = "auto";
+      this.textareaEl.style.height =
+        Math.min(this.textareaEl.scrollHeight, 120) + "px";
+    });
+
+    this.sendBtn.addEventListener("click", () => this.sendMessage());
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /** Attach to a running PTY session — start listening for chat-message events. */
+  async attach(ptyId: string): Promise<void> {
+    this.ptyId = ptyId;
+    this.sendBtn.disabled = false;
+
+    this.unlistenChat = await listen<ChatMessage>(
+      `chat-message-${ptyId}`,
+      (event) => {
+        this.onChatMessage(event.payload);
+      },
+    );
+
+    this.unlistenExit = await listen<number | null>(
+      `pty-exit-${ptyId}`,
+      (event) => {
+        const code = event.payload;
+        this.appendStatusBanner(
+          code !== null && code !== 0
+            ? `Process exited with code ${code}`
+            : "Process exited",
+        );
+        this.detach();
+      },
+    );
+  }
+
+  /** Detach from PTY — stop listening, disable input. */
+  detach(): void {
+    this.ptyId = null;
+    this.sendBtn.disabled = true;
+    this.finalizeStreaming();
+    if (this.unlistenChat) {
+      this.unlistenChat();
+      this.unlistenChat = null;
+    }
+    if (this.unlistenExit) {
+      this.unlistenExit();
+      this.unlistenExit = null;
+    }
+  }
+
+  /** Clear all messages. */
+  clear(): void {
+    this.messagesEl.innerHTML = "";
+    this.streamingBubble = null;
+    this.streamingBody = "";
+    this.streamingType = null;
+  }
+
+  /** Show an informational banner (e.g. welcome text). */
+  appendStatusBanner(text: string): void {
+    const el = document.createElement("div");
+    el.className = "chat-status-banner";
+    el.textContent = text;
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  /** Get the current PTY id (null if not attached). */
+  getPtyId(): string | null {
+    return this.ptyId;
+  }
+
+  // -----------------------------------------------------------------------
+  // Message handling
+  // -----------------------------------------------------------------------
+
+  private onChatMessage(msg: ChatMessage): void {
+    // Streaming: consecutive assistant text/thinking messages accumulate
+    // into the same bubble until a different type arrives.
+    if (
+      msg.role === "assistant" &&
+      (msg.content_type === "text" || msg.content_type === "thinking")
+    ) {
+      if (this.streamingType === msg.content_type && this.streamingBubble) {
+        // Continue accumulating
+        this.streamingBody += msg.body;
+        this.updateStreamingBubble();
+        return;
+      }
+      // New streaming sequence — finalize previous if any
+      this.finalizeStreaming();
+      this.streamingType = msg.content_type;
+      this.streamingBody = msg.body;
+      this.streamingBubble = this.createBubble(msg);
+      this.messagesEl.appendChild(this.streamingBubble);
+      this.updateStreamingBubble();
+      return;
+    }
+
+    // Non-streaming message — finalize any ongoing stream first
+    this.finalizeStreaming();
+
+    switch (msg.content_type) {
+      case "tool_use":
+        this.appendToolUse(msg);
+        break;
+      case "tool_result":
+        this.appendToolResult(msg);
+        break;
+      case "status":
+        this.appendStatusBanner(msg.body);
+        break;
+      default:
+        this.appendBubble(msg);
+    }
+  }
+
+  private finalizeStreaming(): void {
+    if (this.streamingBubble) {
+      // Final render with complete body
+      this.updateStreamingBubble();
+    }
+    this.streamingBubble = null;
+    this.streamingBody = "";
+    this.streamingType = null;
+  }
+
+  private updateStreamingBubble(): void {
+    if (!this.streamingBubble) return;
+
+    const contentEl = this.streamingBubble.querySelector(".bubble-content");
+    if (!contentEl) return;
+
+    if (this.streamingType === "thinking") {
+      // Thinking: update the content inside the <details> element
+      const detailsContent =
+        this.streamingBubble.querySelector(".thinking-content");
+      if (detailsContent) {
+        detailsContent.innerHTML = renderMarkdown(this.streamingBody);
+      }
+    } else {
+      contentEl.innerHTML = renderMarkdown(this.streamingBody);
+    }
+
+    this.scrollToBottom();
+  }
+
+  // -----------------------------------------------------------------------
+  // Bubble creation helpers
+  // -----------------------------------------------------------------------
+
+  private createBubble(msg: ChatMessage): HTMLElement {
+    const wrapper = document.createElement("div");
+    wrapper.className = `chat-bubble-row ${msg.role === "user" ? "bubble-right" : "bubble-left"}`;
+
+    const bubble = document.createElement("div");
+    bubble.className = `chat-bubble chat-bubble-${msg.role}`;
+
+    if (msg.content_type === "thinking") {
+      // Collapsible thinking section
+      const details = document.createElement("details");
+      const summary = document.createElement("summary");
+      summary.className = "thinking-summary";
+      summary.textContent = "Thinking...";
+      const content = document.createElement("div");
+      content.className = "thinking-content bubble-content";
+      content.innerHTML = renderMarkdown(msg.body);
+      details.appendChild(summary);
+      details.appendChild(content);
+      bubble.appendChild(details);
+    } else {
+      const content = document.createElement("div");
+      content.className = "bubble-content";
+      content.innerHTML = renderMarkdown(msg.body);
+      bubble.appendChild(content);
+    }
+
+    wrapper.appendChild(bubble);
+    return wrapper;
+  }
+
+  private appendBubble(msg: ChatMessage): void {
+    const el = this.createBubble(msg);
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  private appendToolUse(msg: ChatMessage): void {
+    const el = document.createElement("div");
+    el.className = "chat-tool-status";
+
+    // Extract tool name from body format "name: {input}"
+    const colonIdx = msg.body.indexOf(":");
+    const toolName = colonIdx > 0 ? msg.body.slice(0, colonIdx) : msg.body;
+
+    el.innerHTML = `<span class="tool-icon">&#9881;</span> <span class="tool-name">${this.escapeHtml(toolName)}</span>`;
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  private appendToolResult(msg: ChatMessage): void {
+    const el = document.createElement("div");
+    el.className = "chat-tool-result";
+    const body = msg.body.length > 300 ? msg.body.slice(0, 300) + "..." : msg.body;
+
+    const details = document.createElement("details");
+    const summary = document.createElement("summary");
+    summary.className = "tool-result-summary";
+    summary.textContent = "Tool result";
+    const content = document.createElement("div");
+    content.className = "tool-result-content";
+    content.innerHTML = `<pre>${this.escapeHtml(body)}</pre>`;
+    details.appendChild(summary);
+    details.appendChild(content);
+    el.appendChild(details);
+
+    this.messagesEl.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  // -----------------------------------------------------------------------
+  // Input handling
+  // -----------------------------------------------------------------------
+
+  private async sendMessage(): Promise<void> {
+    const text = this.textareaEl.value.trim();
+    if (!text || !this.ptyId) return;
+
+    // Display user message as a bubble
+    this.appendBubble({
+      role: "user",
+      content_type: "text",
+      body: text,
+    });
+
+    // Send to PTY stdin as a line
+    try {
+      await invoke("write_pty", { id: this.ptyId, data: text + "\n" });
+    } catch (e) {
+      this.appendStatusBanner(`Send failed: ${e}`);
+    }
+
+    this.textareaEl.value = "";
+    this.textareaEl.style.height = "auto";
+  }
+
+  // -----------------------------------------------------------------------
+  // Utilities
+  // -----------------------------------------------------------------------
+
+  private scrollToBottom(): void {
+    if (this.userScrolled) return;
+    requestAnimationFrame(() => {
+      this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+    });
+  }
+
+  private escapeHtml(text: string): string {
+    const div = document.createElement("div");
+    div.textContent = text;
+    return div.innerHTML;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,6 @@
-import { Terminal } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import "@xterm/xterm/css/xterm.css";
+import "./styles.css";
+import { ChatPane } from "./chat";
 import { invoke } from "@tauri-apps/api/core";
-import { listen, UnlistenFn } from "@tauri-apps/api/event";
 
 interface PaneConfig {
   command: string;
@@ -16,12 +14,8 @@ interface AppConfig {
 }
 
 interface PaneState {
-  terminal: Terminal;
-  fitAddon: FitAddon;
-  ptyId: string | null;
+  chat: ChatPane;
   config: PaneConfig;
-  unlistenData: UnlistenFn | null;
-  unlistenExit: UnlistenFn | null;
 }
 
 const panes: Record<string, PaneState> = {};
@@ -35,8 +29,12 @@ function setStatus(paneId: string, status: AgentStatus) {
   badge.textContent = status.charAt(0).toUpperCase() + status.slice(1);
 
   // Update button disabled states
-  const startBtn = document.querySelector(`.pane-btn[data-action="start"][data-pane="${paneId}"]`) as HTMLButtonElement | null;
-  const stopBtn = document.querySelector(`.pane-btn[data-action="stop"][data-pane="${paneId}"]`) as HTMLButtonElement | null;
+  const startBtn = document.querySelector(
+    `.pane-btn[data-action="start"][data-pane="${paneId}"]`,
+  ) as HTMLButtonElement | null;
+  const stopBtn = document.querySelector(
+    `.pane-btn[data-action="stop"][data-pane="${paneId}"]`,
+  ) as HTMLButtonElement | null;
   if (startBtn) startBtn.disabled = status === "running";
   if (stopBtn) stopBtn.disabled = status !== "running";
 }
@@ -44,131 +42,54 @@ function setStatus(paneId: string, status: AgentStatus) {
 // Currently open settings modal target
 let settingsTargetPane: string | null = null;
 
-function createTerminal(containerId: string): { terminal: Terminal; fitAddon: FitAddon } {
-  const container = document.getElementById(containerId)!;
-  const terminal = new Terminal({
-    fontSize: 13,
-    fontFamily: "'Cascadia Code', 'Consolas', monospace",
-    theme: {
-      background: "#0a0a1a",
-      foreground: "#e0e0e0",
-      cursor: "#64ffda",
-      selectionBackground: "#0f346080",
-    },
-    cursorBlink: true,
-    convertEol: false,
-  });
-  const fitAddon = new FitAddon();
-  terminal.loadAddon(fitAddon);
-  terminal.open(container);
-  fitAddon.fit();
-  return { terminal, fitAddon };
-}
-
 async function startProcess(paneId: string) {
   const pane = panes[paneId];
   if (!pane) return;
-  if (pane.ptyId) {
-    pane.terminal.writeln("\r\n\x1b[33m[Already running]\x1b[0m");
+  if (pane.chat.getPtyId()) {
+    pane.chat.appendStatusBanner("Already running");
     return;
   }
 
   const { command, args, cwd } = pane.config;
-  pane.terminal.writeln(`\x1b[36m[Starting ${command}...]\x1b[0m`);
+  pane.chat.clear();
+  pane.chat.appendStatusBanner(`Starting ${command}...`);
 
   try {
-    const dims = pane.fitAddon.proposeDimensions() ?? { cols: 80, rows: 24 };
-    const cols = dims.cols ?? 80;
-    const rows = dims.rows ?? 24;
+    // Use spawn_stream_pty for structured chat messages
+    // Determine cli_kind from command name
+    const cliKind = command.toLowerCase().includes("codex") ? "codex" : "claude";
 
-    const id = await invoke<string>("spawn_pty", {
+    const id = await invoke<string>("spawn_stream_pty", {
       command,
       args,
-      cols,
-      rows,
+      cols: 120,
+      rows: 40,
       cwd: cwd ?? null,
+      cliKind,
     });
 
-    pane.ptyId = id;
     setStatus(paneId, "running");
-
-    // Listen for PTY output
-    pane.unlistenData = await listen<string>(`pty-data-${id}`, (event) => {
-      pane.terminal.write(event.payload);
-    });
-
-    // Listen for PTY exit (payload is exit code or null)
-    pane.unlistenExit = await listen<number | null>(`pty-exit-${id}`, (event) => {
-      const code = event.payload;
-      if (code !== null && code !== 0) {
-        pane.terminal.writeln(`\r\n\x1b[31m[Exited with code ${code}]\x1b[0m`);
-        setStatus(paneId, "error");
-      } else {
-        pane.terminal.writeln("\r\n\x1b[33m[Process exited]\x1b[0m");
-        setStatus(paneId, "stopped");
-      }
-      cleanupPane(paneId);
-    });
-
-    // Forward terminal input to PTY
-    pane.terminal.onData((data: string) => {
-      if (pane.ptyId) {
-        invoke("write_pty", { id: pane.ptyId, data }).catch(() => {});
-      }
-    });
-
-    // Enable Ctrl+V paste from clipboard
-    pane.terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-      if (e.type === "keydown" && e.ctrlKey && e.key === "v") {
-        navigator.clipboard.readText().then((text) => {
-          if (pane.ptyId && text) {
-            invoke("write_pty", { id: pane.ptyId, data: text }).catch(() => {});
-          }
-        });
-        return false; // prevent xterm default handling
-      }
-      // Ctrl+C: let xterm handle it (sends SIGINT via PTY)
-      return true;
-    });
-
-    // Forward terminal resize to PTY
-    pane.terminal.onResize(({ cols, rows }) => {
-      if (pane.ptyId) {
-        invoke("resize_pty", { id: pane.ptyId, cols, rows }).catch(() => {});
-      }
-    });
+    await pane.chat.attach(id);
   } catch (e) {
-    pane.terminal.writeln(`\r\n\x1b[31m[Failed to start: ${e}]\x1b[0m`);
+    pane.chat.appendStatusBanner(`Failed to start: ${e}`);
     setStatus(paneId, "error");
-  }
-}
-
-function cleanupPane(paneId: string) {
-  const pane = panes[paneId];
-  if (!pane) return;
-  pane.ptyId = null;
-  if (pane.unlistenData) {
-    pane.unlistenData();
-    pane.unlistenData = null;
-  }
-  if (pane.unlistenExit) {
-    pane.unlistenExit();
-    pane.unlistenExit = null;
   }
 }
 
 async function stopProcess(paneId: string) {
   const pane = panes[paneId];
-  if (!pane?.ptyId) return;
-  const id = pane.ptyId;
+  if (!pane) return;
+  const id = pane.chat.getPtyId();
+  if (!id) return;
+
   try {
     await invoke("kill_pty", { id });
-    pane.terminal.writeln("\r\n\x1b[33m[Stopped]\x1b[0m");
+    pane.chat.appendStatusBanner("Stopped");
     setStatus(paneId, "stopped");
   } catch (e) {
-    pane.terminal.writeln(`\r\n\x1b[31m[Stop failed: ${e}]\x1b[0m`);
+    pane.chat.appendStatusBanner(`Stop failed: ${e}`);
   }
-  cleanupPane(paneId);
+  pane.chat.detach();
 }
 
 function openSettingsModal(paneId: string) {
@@ -177,8 +98,12 @@ function openSettingsModal(paneId: string) {
   settingsTargetPane = paneId;
 
   const modal = document.getElementById("settings-modal")!;
-  const cmdInput = document.getElementById("settings-command") as HTMLInputElement;
-  const argsInput = document.getElementById("settings-args") as HTMLInputElement;
+  const cmdInput = document.getElementById(
+    "settings-command",
+  ) as HTMLInputElement;
+  const argsInput = document.getElementById(
+    "settings-args",
+  ) as HTMLInputElement;
   const cwdInput = document.getElementById("settings-cwd") as HTMLInputElement;
 
   cmdInput.value = pane.config.command;
@@ -200,8 +125,12 @@ async function saveSettings() {
   const pane = panes[settingsTargetPane];
   if (!pane) return;
 
-  const cmdInput = document.getElementById("settings-command") as HTMLInputElement;
-  const argsInput = document.getElementById("settings-args") as HTMLInputElement;
+  const cmdInput = document.getElementById(
+    "settings-command",
+  ) as HTMLInputElement;
+  const argsInput = document.getElementById(
+    "settings-args",
+  ) as HTMLInputElement;
   const cwdInput = document.getElementById("settings-cwd") as HTMLInputElement;
 
   const command = cmdInput.value.trim();
@@ -236,7 +165,9 @@ function setupDivider() {
   const rightPane = document.getElementById("pane-right")!;
   let dragging = false;
 
-  divider.addEventListener("mousedown", () => { dragging = true; });
+  divider.addEventListener("mousedown", () => {
+    dragging = true;
+  });
   document.addEventListener("mousemove", (e) => {
     if (!dragging) return;
     const container = document.getElementById("panes")!;
@@ -245,9 +176,10 @@ function setupDivider() {
     const clamped = Math.max(0.2, Math.min(0.8, ratio));
     leftPane.style.flex = `${clamped}`;
     rightPane.style.flex = `${1 - clamped}`;
-    Object.values(panes).forEach((p) => p.fitAddon.fit());
   });
-  document.addEventListener("mouseup", () => { dragging = false; });
+  document.addEventListener("mouseup", () => {
+    dragging = false;
+  });
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
@@ -263,29 +195,24 @@ window.addEventListener("DOMContentLoaded", async () => {
     };
   }
 
-  const left = createTerminal("terminal-left");
+  const leftChat = new ChatPane("chat-left");
   panes["left"] = {
-    ...left,
-    ptyId: null,
+    chat: leftChat,
     config: appConfig.left,
-    unlistenData: null,
-    unlistenExit: null,
   };
 
-  const right = createTerminal("terminal-right");
+  const rightChat = new ChatPane("chat-right");
   panes["right"] = {
-    ...right,
-    ptyId: null,
+    chat: rightChat,
     config: appConfig.right,
-    unlistenData: null,
-    unlistenExit: null,
   };
 
-  panes["left"].terminal.writeln("\x1b[36mLi+ Desktop — Claude Code pane\x1b[0m");
-  panes["left"].terminal.writeln("Press \x1b[32mStart\x1b[0m to launch Claude Code CLI.\r\n");
-
-  panes["right"].terminal.writeln("\x1b[36mLi+ Desktop — Codex pane\x1b[0m");
-  panes["right"].terminal.writeln("Press \x1b[32mStart\x1b[0m to launch Codex CLI.\r\n");
+  leftChat.appendStatusBanner(
+    "Li+ Desktop \u2014 Claude Code pane. Press Start to launch.",
+  );
+  rightChat.appendStatusBanner(
+    "Li+ Desktop \u2014 Codex pane. Press Start to launch.",
+  );
 
   // Set initial button states
   setStatus("left", "stopped");
@@ -304,24 +231,30 @@ window.addEventListener("DOMContentLoaded", async () => {
   });
 
   // Modal button handlers
-  document.getElementById("modal-close")!.addEventListener("click", closeSettingsModal);
-  document.getElementById("settings-cancel")!.addEventListener("click", closeSettingsModal);
-  document.getElementById("settings-save")!.addEventListener("click", saveSettings);
+  document
+    .getElementById("modal-close")!
+    .addEventListener("click", closeSettingsModal);
+  document
+    .getElementById("settings-cancel")!
+    .addEventListener("click", closeSettingsModal);
+  document
+    .getElementById("settings-save")!
+    .addEventListener("click", saveSettings);
 
   // Close modal on overlay click
-  document.getElementById("settings-modal")!.addEventListener("click", (e) => {
-    if (e.target === e.currentTarget) closeSettingsModal();
-  });
+  document
+    .getElementById("settings-modal")!
+    .addEventListener("click", (e) => {
+      if (e.target === e.currentTarget) closeSettingsModal();
+    });
 
   // Save on Enter key
-  document.getElementById("settings-modal")!.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") saveSettings();
-    if (e.key === "Escape") closeSettingsModal();
-  });
+  document
+    .getElementById("settings-modal")!
+    .addEventListener("keydown", (e) => {
+      if (e.key === "Enter") saveSettings();
+      if (e.key === "Escape") closeSettingsModal();
+    });
 
   setupDivider();
-
-  window.addEventListener("resize", () => {
-    Object.values(panes).forEach((p) => p.fitAddon.fit());
-  });
 });

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,0 +1,36 @@
+import { Marked } from "marked";
+import { markedHighlight } from "marked-highlight";
+import hljs from "highlight.js";
+
+/**
+ * Pre-configured Marked instance with syntax highlighting via highlight.js.
+ * Exported as a singleton — all callers share the same renderer config.
+ */
+const marked = new Marked(
+  markedHighlight({
+    emptyLangClass: "hljs",
+    langPrefix: "hljs language-",
+    highlight(code: string, lang: string) {
+      if (lang && hljs.getLanguage(lang)) {
+        return hljs.highlight(code, { language: lang }).value;
+      }
+      return hljs.highlightAuto(code).value;
+    },
+  }),
+);
+
+marked.setOptions({
+  gfm: true,
+  breaks: true,
+});
+
+/**
+ * Render a markdown string to HTML.
+ * Safe for incremental (streaming) use — caller replaces innerHTML each time.
+ */
+export function renderMarkdown(source: string): string {
+  const result = marked.parse(source);
+  // marked.parse can return string or Promise<string> depending on config.
+  // With our synchronous highlight config it always returns string.
+  return result as string;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,5 @@
+@import "highlight.js/styles/github-dark.min.css";
+
 * {
   margin: 0;
   padding: 0;
@@ -87,17 +89,6 @@
   color: #e0e0e0;
 }
 
-.terminal-container {
-  flex: 1;
-  padding: 4px;
-  background: #0a0a1a;
-  overflow: hidden;
-}
-
-.terminal-container .xterm {
-  height: 100%;
-}
-
 /* Status badge */
 .status-badge {
   font-size: 10px;
@@ -148,6 +139,266 @@
 .pane-settings-btn:hover {
   background: #0f3460;
   color: #64ffda;
+}
+
+/* ----------------------------------------------------------------
+   Chat UI
+   ---------------------------------------------------------------- */
+
+.chat-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #0a0a1a;
+  overflow: hidden;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Scrollbar */
+.chat-messages::-webkit-scrollbar {
+  width: 6px;
+}
+.chat-messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+.chat-messages::-webkit-scrollbar-thumb {
+  background: #0f3460;
+  border-radius: 3px;
+}
+
+/* Bubble rows — control alignment */
+.chat-bubble-row {
+  display: flex;
+  max-width: 85%;
+}
+.bubble-left {
+  align-self: flex-start;
+}
+.bubble-right {
+  align-self: flex-end;
+}
+
+/* Bubbles */
+.chat-bubble {
+  border-radius: 12px;
+  padding: 8px 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.chat-bubble-assistant {
+  background: #16213e;
+  color: #e0e0e0;
+  border: 1px solid #0f3460;
+  border-bottom-left-radius: 4px;
+}
+
+.chat-bubble-user {
+  background: #0f3460;
+  color: #e0e0e0;
+  border: 1px solid #1e3a5f;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-bubble-system {
+  background: #1a1a2e;
+  color: #a8b2d1;
+  border: 1px solid #2a2a3a;
+  font-size: 12px;
+}
+
+/* Markdown content inside bubbles */
+.bubble-content p {
+  margin: 0 0 0.4em;
+}
+.bubble-content p:last-child {
+  margin-bottom: 0;
+}
+.bubble-content ul,
+.bubble-content ol {
+  margin: 0.3em 0;
+  padding-left: 1.4em;
+}
+.bubble-content code {
+  background: #0a0a1a;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: "Cascadia Code", "Consolas", monospace;
+}
+.bubble-content pre {
+  background: #0a0a1a;
+  border: 1px solid #0f3460;
+  border-radius: 6px;
+  padding: 10px;
+  margin: 6px 0;
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.bubble-content pre code {
+  background: none;
+  padding: 0;
+}
+.bubble-content table {
+  border-collapse: collapse;
+  margin: 6px 0;
+  font-size: 12px;
+}
+.bubble-content th,
+.bubble-content td {
+  border: 1px solid #0f3460;
+  padding: 4px 8px;
+}
+.bubble-content th {
+  background: #16213e;
+}
+.bubble-content a {
+  color: #64ffda;
+}
+.bubble-content blockquote {
+  border-left: 3px solid #0f3460;
+  padding-left: 10px;
+  margin: 6px 0;
+  color: #a8b2d1;
+}
+
+/* Thinking — collapsible */
+.thinking-summary {
+  cursor: pointer;
+  color: #a8b2d1;
+  font-size: 12px;
+  user-select: none;
+  padding: 2px 0;
+}
+.thinking-summary:hover {
+  color: #e0e0e0;
+}
+.thinking-content {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid #0f3460;
+  color: #a8b2d1;
+  font-size: 12px;
+}
+
+/* Tool use / result compact displays */
+.chat-tool-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  font-size: 12px;
+  color: #a8b2d1;
+}
+.tool-icon {
+  font-size: 14px;
+  color: #64ffda;
+}
+.tool-name {
+  font-family: "Cascadia Code", "Consolas", monospace;
+  color: #64ffda;
+}
+
+.chat-tool-result {
+  padding: 2px 12px;
+  font-size: 12px;
+}
+.tool-result-summary {
+  cursor: pointer;
+  color: #6b7280;
+  font-size: 11px;
+  user-select: none;
+}
+.tool-result-summary:hover {
+  color: #a8b2d1;
+}
+.tool-result-content {
+  margin-top: 4px;
+}
+.tool-result-content pre {
+  background: #0a0a1a;
+  border: 1px solid #0f3460;
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 11px;
+  color: #a8b2d1;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* Status banners */
+.chat-status-banner {
+  text-align: center;
+  padding: 4px 10px;
+  font-size: 11px;
+  color: #6b7280;
+  user-select: none;
+}
+
+/* Input area */
+.chat-input-area {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 8px 10px;
+  border-top: 1px solid #0f3460;
+  background: #0a0a1a;
+}
+
+.chat-textarea {
+  flex: 1;
+  resize: none;
+  background: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 8px;
+  color: #e0e0e0;
+  font-size: 13px;
+  font-family: inherit;
+  padding: 8px 12px;
+  outline: none;
+  line-height: 1.4;
+  max-height: 120px;
+  overflow-y: auto;
+}
+.chat-textarea:focus {
+  border-color: #64ffda;
+}
+.chat-textarea::placeholder {
+  color: #4a5568;
+}
+
+.chat-send-btn {
+  padding: 8px 16px;
+  border: 1px solid #64ffda;
+  border-radius: 8px;
+  background: #0f3460;
+  color: #64ffda;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.chat-send-btn:hover:not(:disabled) {
+  background: #64ffda;
+  color: #0a0a1a;
+}
+.chat-send-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }
 
 /* Modal */


### PR DESCRIPTION
Refs #22

xterm.js ターミナル表示を廃止し、チャットバブル形式の UI に置き換え。
#21 の統一 ChatMessage 型を受け取り、メッセージ種別に応じた表示を行う。

- `src/chat.ts`: ChatPane クラス（メッセージ表示、ストリーミング、入力、スクロール管理）
- `src/markdown.ts`: marked + highlight.js ラッパー
- `src/main.ts`: xterm.js → ChatPane に書き換え、`spawn_stream_pty` 使用
- `src/styles.css`: チャットバブル・入力欄スタイル（ダークテーマ維持）
- `index.html`: terminal-container → chat-container
- `package.json`: xterm/plugin-shell 削除、marked/highlight.js 追加