### PR TITLE
feat(ui): replace 2-pane layout with agent type tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,45 +12,33 @@
       <header id="titlebar">
         <span class="title">Li+ Desktop</span>
       </header>
-      <div id="panes">
-        <div class="pane" id="pane-left">
-          <div class="pane-header">
-            <span class="pane-label">Claude Code</span>
-            <span class="status-badge status-stopped" id="status-left">Stopped</span>
-            <button class="pane-btn" data-action="start" data-pane="left">Start</button>
-            <button class="pane-btn" data-action="stop" data-pane="left">Stop</button>
-            <button class="pane-btn pane-settings-btn" data-action="settings" data-pane="left">⚙</button>
-          </div>
-          <div class="chat-container" id="chat-left"></div>
-        </div>
-        <div id="divider"></div>
-        <div class="pane" id="pane-right">
-          <div class="pane-header">
-            <span class="pane-label">Codex</span>
-            <span class="status-badge status-stopped" id="status-right">Stopped</span>
-            <button class="pane-btn" data-action="start" data-pane="right">Start</button>
-            <button class="pane-btn" data-action="stop" data-pane="right">Stop</button>
-            <button class="pane-btn pane-settings-btn" data-action="settings" data-pane="right">⚙</button>
-          </div>
-          <div class="chat-container" id="chat-right"></div>
-        </div>
-      </div>
+      <div id="tab-bar"></div>
+      <div id="tab-toolbar" class="tab-toolbar"></div>
+      <div id="tab-content-area"></div>
     </div>
 
     <!-- Settings Modal -->
     <div id="settings-modal" class="modal-overlay" style="display:none">
       <div class="modal-box">
         <div class="modal-header">
-          <span class="modal-title">Pane Settings</span>
-          <button id="modal-close" class="modal-close-btn">✕</button>
+          <span class="modal-title">Tab Settings</span>
+          <button id="modal-close" class="modal-close-btn">&#x2715;</button>
         </div>
         <div class="modal-body">
+          <label class="modal-label">Name</label>
+          <input id="settings-name" class="modal-input" type="text" placeholder="e.g. Claude Code" />
           <label class="modal-label">Command</label>
           <input id="settings-command" class="modal-input" type="text" placeholder="e.g. claude" />
           <label class="modal-label">Args <span class="modal-hint">(comma-separated)</span></label>
           <input id="settings-args" class="modal-input" type="text" placeholder="e.g. --no-update-notifier" />
           <label class="modal-label">Working Directory <span class="modal-hint">(leave blank for default)</span></label>
           <input id="settings-cwd" class="modal-input" type="text" placeholder="e.g. C:\Users\you\projects" />
+          <label class="modal-label">CLI Kind</label>
+          <select id="settings-cli-kind" class="modal-input">
+            <option value="claude">Claude</option>
+            <option value="codex">Codex</option>
+            <option value="gemini">Gemini</option>
+          </select>
         </div>
         <div class="modal-footer">
           <button id="settings-save" class="modal-save-btn">Save</button>

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -4,31 +4,65 @@ use tauri::AppHandle;
 use tauri::Manager;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PaneConfig {
+pub struct TabConfig {
+    pub id: String,
+    pub name: String,
     pub command: String,
     pub args: Vec<String>,
     pub cwd: Option<String>,
+    pub cli_kind: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
-    pub left: PaneConfig,
-    pub right: PaneConfig,
+    pub tabs: Vec<TabConfig>,
+}
+
+/// Legacy config format for migration
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyPaneConfig {
+    command: String,
+    args: Vec<String>,
+    cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyAppConfig {
+    left: LegacyPaneConfig,
+    right: LegacyPaneConfig,
+}
+
+fn cli_kind_from_command(command: &str) -> String {
+    if command.to_lowercase().contains("codex") {
+        "codex".to_string()
+    } else if command.to_lowercase().contains("gemini") {
+        "gemini".to_string()
+    } else {
+        "claude".to_string()
+    }
 }
 
 impl Default for AppConfig {
     fn default() -> Self {
         AppConfig {
-            left: PaneConfig {
-                command: "claude".to_string(),
-                args: vec![],
-                cwd: None,
-            },
-            right: PaneConfig {
-                command: "codex".to_string(),
-                args: vec![],
-                cwd: None,
-            },
+            tabs: vec![
+                TabConfig {
+                    id: "tab-1".to_string(),
+                    name: "Claude Code".to_string(),
+                    command: "claude".to_string(),
+                    args: vec![],
+                    cwd: None,
+                    cli_kind: "claude".to_string(),
+                },
+                TabConfig {
+                    id: "tab-2".to_string(),
+                    name: "Codex".to_string(),
+                    command: "codex".to_string(),
+                    args: vec![],
+                    cwd: None,
+                    cli_kind: "codex".to_string(),
+                },
+            ],
         }
     }
 }
@@ -49,7 +83,42 @@ pub fn load_config(app: AppHandle) -> Result<AppConfig, String> {
     }
     let content =
         std::fs::read_to_string(&path).map_err(|e| format!("Failed to read config: {e}"))?;
-    serde_json::from_str(&content).map_err(|e| format!("Failed to parse config: {e}"))
+
+    // Try parsing as new format first
+    if let Ok(config) = serde_json::from_str::<AppConfig>(&content) {
+        return Ok(config);
+    }
+
+    // Fall back to legacy left/right format and migrate
+    if let Ok(legacy) = serde_json::from_str::<LegacyAppConfig>(&content) {
+        let migrated = AppConfig {
+            tabs: vec![
+                TabConfig {
+                    id: "tab-1".to_string(),
+                    name: "Claude Code".to_string(),
+                    command: legacy.left.command.clone(),
+                    args: legacy.left.args,
+                    cwd: legacy.left.cwd,
+                    cli_kind: cli_kind_from_command(&legacy.left.command),
+                },
+                TabConfig {
+                    id: "tab-2".to_string(),
+                    name: "Codex".to_string(),
+                    command: legacy.right.command.clone(),
+                    args: legacy.right.args,
+                    cwd: legacy.right.cwd,
+                    cli_kind: cli_kind_from_command(&legacy.right.command),
+                },
+            ],
+        };
+        // Save migrated config
+        if let Ok(json) = serde_json::to_string_pretty(&migrated) {
+            let _ = std::fs::write(&path, json);
+        }
+        return Ok(migrated);
+    }
+
+    Err("Failed to parse config: unrecognized format".to_string())
 }
 
 #[tauri::command]

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -17,7 +17,7 @@ interface ChatMessage {
 }
 
 // ---------------------------------------------------------------------------
-// ChatPane — one chat UI instance (left or right pane)
+// ChatPane — one chat UI instance
 // ---------------------------------------------------------------------------
 
 export class ChatPane {
@@ -37,8 +37,17 @@ export class ChatPane {
   /** Content type of the current streaming message */
   private streamingType: ContentType | null = null;
 
-  constructor(containerId: string) {
-    this.container = document.getElementById(containerId)!;
+  /**
+   * @param containerOrId - Either an HTMLElement to use as the container,
+   *   or a string element ID (legacy support).
+   */
+  constructor(containerOrId: HTMLElement | string) {
+    if (typeof containerOrId === "string") {
+      this.container = document.getElementById(containerOrId)!;
+    } else {
+      this.container = containerOrId;
+    }
+    this.container.classList.add("chat-container");
 
     // Build DOM structure
     this.messagesEl = document.createElement("div");
@@ -94,8 +103,11 @@ export class ChatPane {
   // Public API
   // -----------------------------------------------------------------------
 
-  /** Attach to a running PTY session — start listening for chat-message events. */
-  async attach(ptyId: string): Promise<void> {
+  /**
+   * Attach to a running PTY session — start listening for chat-message events.
+   * @param onExit - Optional callback invoked when the PTY process exits.
+   */
+  async attach(ptyId: string, onExit?: () => void): Promise<void> {
     this.ptyId = ptyId;
     this.sendBtn.disabled = false;
 
@@ -116,6 +128,7 @@ export class ChatPane {
             : "Process exited",
         );
         this.detach();
+        if (onExit) onExit();
       },
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,188 +1,27 @@
 import "./styles.css";
-import { ChatPane } from "./chat";
+import { TabManager, AppConfig } from "./tabs";
 import { invoke } from "@tauri-apps/api/core";
-
-interface PaneConfig {
-  command: string;
-  args: string[];
-  cwd: string | null;
-}
-
-interface AppConfig {
-  left: PaneConfig;
-  right: PaneConfig;
-}
-
-interface PaneState {
-  chat: ChatPane;
-  config: PaneConfig;
-}
-
-const panes: Record<string, PaneState> = {};
-
-type AgentStatus = "stopped" | "running" | "error";
-
-function setStatus(paneId: string, status: AgentStatus) {
-  const badge = document.getElementById(`status-${paneId}`);
-  if (!badge) return;
-  badge.className = `status-badge status-${status}`;
-  badge.textContent = status.charAt(0).toUpperCase() + status.slice(1);
-
-  // Update button disabled states
-  const startBtn = document.querySelector(
-    `.pane-btn[data-action="start"][data-pane="${paneId}"]`,
-  ) as HTMLButtonElement | null;
-  const stopBtn = document.querySelector(
-    `.pane-btn[data-action="stop"][data-pane="${paneId}"]`,
-  ) as HTMLButtonElement | null;
-  if (startBtn) startBtn.disabled = status === "running";
-  if (stopBtn) stopBtn.disabled = status !== "running";
-}
-
-// Currently open settings modal target
-let settingsTargetPane: string | null = null;
-
-async function startProcess(paneId: string) {
-  const pane = panes[paneId];
-  if (!pane) return;
-  if (pane.chat.getPtyId()) {
-    pane.chat.appendStatusBanner("Already running");
-    return;
-  }
-
-  const { command, args, cwd } = pane.config;
-  pane.chat.clear();
-  pane.chat.appendStatusBanner(`Starting ${command}...`);
-
-  try {
-    // Use spawn_stream_pty for structured chat messages
-    // Determine cli_kind from command name
-    const cliKind = command.toLowerCase().includes("codex") ? "codex" : "claude";
-
-    const id = await invoke<string>("spawn_stream_pty", {
-      command,
-      args,
-      cols: 120,
-      rows: 40,
-      cwd: cwd ?? null,
-      cliKind,
-    });
-
-    setStatus(paneId, "running");
-    await pane.chat.attach(id);
-  } catch (e) {
-    pane.chat.appendStatusBanner(`Failed to start: ${e}`);
-    setStatus(paneId, "error");
-  }
-}
-
-async function stopProcess(paneId: string) {
-  const pane = panes[paneId];
-  if (!pane) return;
-  const id = pane.chat.getPtyId();
-  if (!id) return;
-
-  try {
-    await invoke("kill_pty", { id });
-    pane.chat.appendStatusBanner("Stopped");
-    setStatus(paneId, "stopped");
-  } catch (e) {
-    pane.chat.appendStatusBanner(`Stop failed: ${e}`);
-  }
-  pane.chat.detach();
-}
-
-function openSettingsModal(paneId: string) {
-  const pane = panes[paneId];
-  if (!pane) return;
-  settingsTargetPane = paneId;
-
-  const modal = document.getElementById("settings-modal")!;
-  const cmdInput = document.getElementById(
-    "settings-command",
-  ) as HTMLInputElement;
-  const argsInput = document.getElementById(
-    "settings-args",
-  ) as HTMLInputElement;
-  const cwdInput = document.getElementById("settings-cwd") as HTMLInputElement;
-
-  cmdInput.value = pane.config.command;
-  argsInput.value = pane.config.args.join(", ");
-  cwdInput.value = pane.config.cwd ?? "";
-
-  modal.style.display = "flex";
-  cmdInput.focus();
-}
 
 function closeSettingsModal() {
   const modal = document.getElementById("settings-modal")!;
   modal.style.display = "none";
-  settingsTargetPane = null;
-}
-
-async function saveSettings() {
-  if (!settingsTargetPane) return;
-  const pane = panes[settingsTargetPane];
-  if (!pane) return;
-
-  const cmdInput = document.getElementById(
-    "settings-command",
-  ) as HTMLInputElement;
-  const argsInput = document.getElementById(
-    "settings-args",
-  ) as HTMLInputElement;
-  const cwdInput = document.getElementById("settings-cwd") as HTMLInputElement;
-
-  const command = cmdInput.value.trim();
-  const args = argsInput.value
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-  const cwd = cwdInput.value.trim() || null;
-
-  if (!command) return;
-
-  pane.config = { command, args, cwd };
-
-  // Build full config and persist
-  const config: AppConfig = {
-    left: panes["left"].config,
-    right: panes["right"].config,
-  };
-
-  try {
-    await invoke("save_config", { config });
-  } catch (e) {
-    console.error("Failed to save config:", e);
-  }
-
-  closeSettingsModal();
-}
-
-function setupDivider() {
-  const divider = document.getElementById("divider")!;
-  const leftPane = document.getElementById("pane-left")!;
-  const rightPane = document.getElementById("pane-right")!;
-  let dragging = false;
-
-  divider.addEventListener("mousedown", () => {
-    dragging = true;
-  });
-  document.addEventListener("mousemove", (e) => {
-    if (!dragging) return;
-    const container = document.getElementById("panes")!;
-    const rect = container.getBoundingClientRect();
-    const ratio = (e.clientX - rect.left) / rect.width;
-    const clamped = Math.max(0.2, Math.min(0.8, ratio));
-    leftPane.style.flex = `${clamped}`;
-    rightPane.style.flex = `${1 - clamped}`;
-  });
-  document.addEventListener("mouseup", () => {
-    dragging = false;
-  });
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
+  const tabBarEl = document.getElementById("tab-bar")!;
+  const contentAreaEl = document.getElementById("tab-content-area")!;
+
+  const manager = new TabManager(tabBarEl, contentAreaEl);
+
+  // Persist config on change
+  manager.onConfigChange = async (config: AppConfig) => {
+    try {
+      await invoke("save_config", { config });
+    } catch (e) {
+      console.error("Failed to save config:", e);
+    }
+  };
+
   // Load persisted config (falls back to defaults on first run)
   let appConfig: AppConfig;
   try {
@@ -190,45 +29,28 @@ window.addEventListener("DOMContentLoaded", async () => {
   } catch (e) {
     console.error("Failed to load config, using defaults:", e);
     appConfig = {
-      left: { command: "claude", args: [], cwd: null },
-      right: { command: "codex", args: [], cwd: null },
+      tabs: [
+        {
+          id: "tab-1",
+          name: "Claude Code",
+          command: "claude",
+          args: [],
+          cwd: null,
+          cli_kind: "claude",
+        },
+        {
+          id: "tab-2",
+          name: "Codex",
+          command: "codex",
+          args: [],
+          cwd: null,
+          cli_kind: "codex",
+        },
+      ],
     };
   }
 
-  const leftChat = new ChatPane("chat-left");
-  panes["left"] = {
-    chat: leftChat,
-    config: appConfig.left,
-  };
-
-  const rightChat = new ChatPane("chat-right");
-  panes["right"] = {
-    chat: rightChat,
-    config: appConfig.right,
-  };
-
-  leftChat.appendStatusBanner(
-    "Li+ Desktop \u2014 Claude Code pane. Press Start to launch.",
-  );
-  rightChat.appendStatusBanner(
-    "Li+ Desktop \u2014 Codex pane. Press Start to launch.",
-  );
-
-  // Set initial button states
-  setStatus("left", "stopped");
-  setStatus("right", "stopped");
-
-  // Pane button handlers
-  document.querySelectorAll(".pane-btn").forEach((btn) => {
-    const el = btn as HTMLButtonElement;
-    const action = el.dataset.action!;
-    const paneId = el.dataset.pane!;
-    el.addEventListener("click", () => {
-      if (action === "start") startProcess(paneId);
-      else if (action === "stop") stopProcess(paneId);
-      else if (action === "settings") openSettingsModal(paneId);
-    });
-  });
+  manager.loadTabs(appConfig);
 
   // Modal button handlers
   document
@@ -239,7 +61,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     .addEventListener("click", closeSettingsModal);
   document
     .getElementById("settings-save")!
-    .addEventListener("click", saveSettings);
+    .addEventListener("click", () => manager.saveFromModal());
 
   // Close modal on overlay click
   document
@@ -248,13 +70,11 @@ window.addEventListener("DOMContentLoaded", async () => {
       if (e.target === e.currentTarget) closeSettingsModal();
     });
 
-  // Save on Enter key
+  // Keyboard shortcuts in modal
   document
     .getElementById("settings-modal")!
     .addEventListener("keydown", (e) => {
-      if (e.key === "Enter") saveSettings();
+      if (e.key === "Enter") manager.saveFromModal();
       if (e.key === "Escape") closeSettingsModal();
     });
-
-  setupDivider();
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -37,36 +37,143 @@
   color: #a8b2d1;
 }
 
-#panes {
+/* ----------------------------------------------------------------
+   Tab bar
+   ---------------------------------------------------------------- */
+
+#tab-bar {
   display: flex;
-  flex: 1;
-  overflow: hidden;
+  align-items: stretch;
+  background: #16213e;
+  border-bottom: 1px solid #0f3460;
+  overflow-x: auto;
+  overflow-y: hidden;
+  min-height: 34px;
+  scrollbar-width: thin;
+  scrollbar-color: #0f3460 transparent;
 }
 
-.pane {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
+#tab-bar::-webkit-scrollbar {
+  height: 3px;
 }
-
-#divider {
-  width: 3px;
+#tab-bar::-webkit-scrollbar-track {
+  background: transparent;
+}
+#tab-bar::-webkit-scrollbar-thumb {
   background: #0f3460;
-  cursor: col-resize;
+  border-radius: 2px;
 }
 
-.pane-header {
-  height: 32px;
+.tab-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  height: 34px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  border-right: 1px solid #0f3460;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+.tab-item:hover {
+  background: #1e2d4a;
+}
+
+.tab-item.tab-active {
+  background: #0a0a1a;
+  border-bottom: 2px solid #64ffda;
+}
+
+.tab-item.tab-dragging {
+  opacity: 0.5;
+}
+
+.tab-item.tab-dragover {
+  border-left: 2px solid #64ffda;
+}
+
+.tab-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: #a8b2d1;
+}
+
+.tab-active .tab-name {
+  color: #e0e0e0;
+}
+
+.tab-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-dot-stopped {
+  background: #4a5568;
+}
+
+.status-dot-running {
+  background: #34d399;
+}
+
+.status-dot-error {
+  background: #f87171;
+}
+
+.tab-close-btn {
+  background: none;
+  border: none;
+  color: #6b7280;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.tab-close-btn:hover {
+  color: #f87171;
+}
+
+.tab-add-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  background: none;
+  border: none;
+  border-right: 1px solid #0f3460;
+  color: #64ffda;
+  font-size: 18px;
+  cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+.tab-add-btn:hover {
+  background: #1e2d4a;
+}
+
+/* ----------------------------------------------------------------
+   Toolbar — per-active-tab controls
+   ---------------------------------------------------------------- */
+
+.tab-toolbar {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 0 10px;
+  height: 32px;
   background: #16213e;
   border-bottom: 1px solid #0f3460;
 }
 
-.pane-label {
+.toolbar-label {
   font-weight: 600;
   font-size: 12px;
   color: #64ffda;
@@ -139,6 +246,24 @@
 .pane-settings-btn:hover {
   background: #0f3460;
   color: #64ffda;
+}
+
+/* ----------------------------------------------------------------
+   Tab content area
+   ---------------------------------------------------------------- */
+
+#tab-content-area {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.tab-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #0a0a1a;
+  overflow: hidden;
 }
 
 /* ----------------------------------------------------------------
@@ -401,7 +526,10 @@
   cursor: not-allowed;
 }
 
-/* Modal */
+/* ----------------------------------------------------------------
+   Modal
+   ---------------------------------------------------------------- */
+
 .modal-overlay {
   position: fixed;
   inset: 0;
@@ -483,6 +611,21 @@
 
 .modal-input:focus {
   border-color: #64ffda;
+}
+
+/* Select element styling */
+select.modal-input {
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23a8b2d1'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  padding-right: 24px;
+}
+
+select.modal-input option {
+  background: #0a0a1a;
+  color: #e0e0e0;
 }
 
 .modal-footer {

--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -1,0 +1,501 @@
+import { ChatPane } from "./chat";
+import { invoke } from "@tauri-apps/api/core";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors Rust TabConfig
+// ---------------------------------------------------------------------------
+
+export interface TabConfig {
+  id: string;
+  name: string;
+  command: string;
+  args: string[];
+  cwd: string | null;
+  cli_kind: string;
+}
+
+export interface AppConfig {
+  tabs: TabConfig[];
+}
+
+export type AgentStatus = "stopped" | "running" | "error";
+
+// ---------------------------------------------------------------------------
+// TabState — one tab's runtime state
+// ---------------------------------------------------------------------------
+
+interface TabState {
+  config: TabConfig;
+  chat: ChatPane;
+  containerEl: HTMLElement;
+  tabEl: HTMLElement;
+  status: AgentStatus;
+}
+
+// ---------------------------------------------------------------------------
+// TabManager — owns the tab bar and all tab instances
+// ---------------------------------------------------------------------------
+
+export class TabManager {
+  private tabs: Map<string, TabState> = new Map();
+  private activeTabId: string | null = null;
+  private tabBarEl: HTMLElement;
+  private contentAreaEl: HTMLElement;
+  private nextTabNum = 1;
+
+  /** Callback when config changes (for persistence). */
+  onConfigChange: ((config: AppConfig) => void) | null = null;
+
+  constructor(tabBarEl: HTMLElement, contentAreaEl: HTMLElement) {
+    this.tabBarEl = tabBarEl;
+    this.contentAreaEl = contentAreaEl;
+
+    // Add-tab button
+    const addBtn = document.createElement("button");
+    addBtn.className = "tab-add-btn";
+    addBtn.textContent = "+";
+    addBtn.title = "Add agent tab";
+    addBtn.addEventListener("click", () => this.openAddDialog());
+    this.tabBarEl.appendChild(addBtn);
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /** Load tabs from persisted config. */
+  loadTabs(config: AppConfig): void {
+    for (const tabCfg of config.tabs) {
+      this.createTab(tabCfg, false);
+    }
+    // Activate first tab
+    if (config.tabs.length > 0) {
+      this.activateTab(config.tabs[0].id);
+    }
+    // Track next id number
+    const nums = config.tabs
+      .map((t) => {
+        const m = t.id.match(/^tab-(\d+)$/);
+        return m ? parseInt(m[1], 10) : 0;
+      })
+      .filter((n) => n > 0);
+    this.nextTabNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
+  }
+
+  /** Get the current config for persistence. */
+  getConfig(): AppConfig {
+    const tabs: TabConfig[] = [];
+    // Preserve DOM order
+    const tabEls = this.tabBarEl.querySelectorAll<HTMLElement>(".tab-item");
+    for (const el of tabEls) {
+      const id = el.dataset.tabId;
+      if (id) {
+        const state = this.tabs.get(id);
+        if (state) tabs.push({ ...state.config });
+      }
+    }
+    return { tabs };
+  }
+
+  /** Start the process for a tab. */
+  async startTab(tabId: string): Promise<void> {
+    const state = this.tabs.get(tabId);
+    if (!state) return;
+    if (state.chat.getPtyId()) {
+      state.chat.appendStatusBanner("Already running");
+      return;
+    }
+
+    const { command, args, cwd, cli_kind } = state.config;
+    state.chat.clear();
+    state.chat.appendStatusBanner(`Starting ${command}...`);
+
+    try {
+      const id = await invoke<string>("spawn_stream_pty", {
+        command,
+        args,
+        cols: 120,
+        rows: 40,
+        cwd: cwd ?? null,
+        cliKind: cli_kind,
+      });
+
+      this.setStatus(tabId, "running");
+      await state.chat.attach(id, () => {
+        this.setStatus(tabId, "stopped");
+      });
+    } catch (e) {
+      state.chat.appendStatusBanner(`Failed to start: ${e}`);
+      this.setStatus(tabId, "error");
+    }
+  }
+
+  /** Stop the process for a tab. */
+  async stopTab(tabId: string): Promise<void> {
+    const state = this.tabs.get(tabId);
+    if (!state) return;
+    const ptyId = state.chat.getPtyId();
+    if (!ptyId) return;
+
+    try {
+      await invoke("kill_pty", { id: ptyId });
+      state.chat.appendStatusBanner("Stopped");
+      this.setStatus(tabId, "stopped");
+    } catch (e) {
+      state.chat.appendStatusBanner(`Stop failed: ${e}`);
+    }
+    state.chat.detach();
+  }
+
+  // -----------------------------------------------------------------------
+  // Tab lifecycle
+  // -----------------------------------------------------------------------
+
+  private createTab(cfg: TabConfig, activate: boolean): void {
+    // Chat container (hidden by default)
+    const containerEl = document.createElement("div");
+    containerEl.className = "tab-content";
+    containerEl.dataset.tabId = cfg.id;
+    containerEl.style.display = "none";
+    this.contentAreaEl.appendChild(containerEl);
+
+    // ChatPane builds its DOM inside the container
+    const chat = new ChatPane(containerEl);
+    chat.appendStatusBanner(
+      `Li+ Desktop \u2014 ${cfg.name} tab. Press Start to launch.`,
+    );
+
+    // Tab bar item
+    const tabEl = document.createElement("div");
+    tabEl.className = "tab-item";
+    tabEl.dataset.tabId = cfg.id;
+    tabEl.draggable = true;
+
+    const nameSpan = document.createElement("span");
+    nameSpan.className = "tab-name";
+    nameSpan.textContent = cfg.name;
+
+    const statusSpan = document.createElement("span");
+    statusSpan.className = "tab-status-dot status-dot-stopped";
+    statusSpan.dataset.tabId = cfg.id;
+
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "tab-close-btn";
+    closeBtn.textContent = "\u00d7";
+    closeBtn.title = "Close tab";
+    closeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closeTab(cfg.id);
+    });
+
+    tabEl.appendChild(statusSpan);
+    tabEl.appendChild(nameSpan);
+    tabEl.appendChild(closeBtn);
+
+    tabEl.addEventListener("click", () => this.activateTab(cfg.id));
+    tabEl.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      this.openSettingsDialog(cfg.id);
+    });
+
+    // Drag & drop reorder
+    tabEl.addEventListener("dragstart", (e) => {
+      e.dataTransfer?.setData("text/plain", cfg.id);
+      tabEl.classList.add("tab-dragging");
+    });
+    tabEl.addEventListener("dragend", () => {
+      tabEl.classList.remove("tab-dragging");
+    });
+    tabEl.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      tabEl.classList.add("tab-dragover");
+    });
+    tabEl.addEventListener("dragleave", () => {
+      tabEl.classList.remove("tab-dragover");
+    });
+    tabEl.addEventListener("drop", (e) => {
+      e.preventDefault();
+      tabEl.classList.remove("tab-dragover");
+      const draggedId = e.dataTransfer?.getData("text/plain");
+      if (draggedId && draggedId !== cfg.id) {
+        this.reorderTab(draggedId, cfg.id);
+      }
+    });
+
+    // Insert before the "+" button
+    const addBtn = this.tabBarEl.querySelector(".tab-add-btn");
+    this.tabBarEl.insertBefore(tabEl, addBtn);
+
+    this.tabs.set(cfg.id, {
+      config: cfg,
+      chat,
+      containerEl,
+      tabEl,
+      status: "stopped",
+    });
+
+    if (activate) {
+      this.activateTab(cfg.id);
+    }
+  }
+
+  private activateTab(tabId: string): void {
+    if (this.activeTabId === tabId) return;
+
+    // Deactivate current
+    if (this.activeTabId) {
+      const prev = this.tabs.get(this.activeTabId);
+      if (prev) {
+        prev.containerEl.style.display = "none";
+        prev.tabEl.classList.remove("tab-active");
+      }
+    }
+
+    // Activate new
+    const state = this.tabs.get(tabId);
+    if (state) {
+      state.containerEl.style.display = "flex";
+      state.tabEl.classList.add("tab-active");
+      this.activeTabId = tabId;
+      this.updateToolbar(state);
+    }
+  }
+
+  private async closeTab(tabId: string): Promise<void> {
+    const state = this.tabs.get(tabId);
+    if (!state) return;
+
+    // Kill PTY if running
+    const ptyId = state.chat.getPtyId();
+    if (ptyId) {
+      try {
+        await invoke("kill_pty", { id: ptyId });
+      } catch (_) {
+        // ignore
+      }
+      state.chat.detach();
+    }
+
+    // Remove DOM
+    state.tabEl.remove();
+    state.containerEl.remove();
+    this.tabs.delete(tabId);
+
+    // If the closed tab was active, switch to the first remaining
+    if (this.activeTabId === tabId) {
+      this.activeTabId = null;
+      const firstTab = this.tabBarEl.querySelector<HTMLElement>(".tab-item");
+      if (firstTab?.dataset.tabId) {
+        this.activateTab(firstTab.dataset.tabId);
+      } else {
+        this.updateToolbar(null);
+      }
+    }
+
+    this.persistConfig();
+  }
+
+  private reorderTab(draggedId: string, targetId: string): void {
+    const draggedState = this.tabs.get(draggedId);
+    const targetState = this.tabs.get(targetId);
+    if (!draggedState || !targetState) return;
+
+    // Move in DOM
+    this.tabBarEl.insertBefore(draggedState.tabEl, targetState.tabEl);
+    this.persistConfig();
+  }
+
+  // -----------------------------------------------------------------------
+  // Status management
+  // -----------------------------------------------------------------------
+
+  private setStatus(tabId: string, status: AgentStatus): void {
+    const state = this.tabs.get(tabId);
+    if (!state) return;
+    state.status = status;
+
+    // Update dot indicator
+    const dot = state.tabEl.querySelector<HTMLElement>(".tab-status-dot");
+    if (dot) {
+      dot.className = `tab-status-dot status-dot-${status}`;
+    }
+
+    // Update toolbar if this is the active tab
+    if (this.activeTabId === tabId) {
+      this.updateToolbar(state);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Toolbar — shown above the content area for the active tab
+  // -----------------------------------------------------------------------
+
+  private updateToolbar(state: TabState | null): void {
+    const toolbar = document.getElementById("tab-toolbar");
+    if (!toolbar) return;
+
+    if (!state) {
+      toolbar.innerHTML = "";
+      return;
+    }
+
+    toolbar.innerHTML = "";
+
+    const label = document.createElement("span");
+    label.className = "toolbar-label";
+    label.textContent = state.config.name;
+
+    const badge = document.createElement("span");
+    badge.className = `status-badge status-${state.status}`;
+    badge.textContent =
+      state.status.charAt(0).toUpperCase() + state.status.slice(1);
+
+    const startBtn = document.createElement("button");
+    startBtn.className = "pane-btn";
+    startBtn.textContent = "Start";
+    startBtn.disabled = state.status === "running";
+    startBtn.addEventListener("click", () => this.startTab(state.config.id));
+
+    const stopBtn = document.createElement("button");
+    stopBtn.className = "pane-btn";
+    stopBtn.textContent = "Stop";
+    stopBtn.disabled = state.status !== "running";
+    stopBtn.addEventListener("click", () => this.stopTab(state.config.id));
+
+    const settingsBtn = document.createElement("button");
+    settingsBtn.className = "pane-btn pane-settings-btn";
+    settingsBtn.textContent = "\u2699";
+    settingsBtn.addEventListener("click", () =>
+      this.openSettingsDialog(state.config.id),
+    );
+
+    toolbar.appendChild(label);
+    toolbar.appendChild(badge);
+    toolbar.appendChild(startBtn);
+    toolbar.appendChild(stopBtn);
+    toolbar.appendChild(settingsBtn);
+  }
+
+  // -----------------------------------------------------------------------
+  // Dialogs
+  // -----------------------------------------------------------------------
+
+  private openAddDialog(): void {
+    this.showSettingsModal(null);
+  }
+
+  private openSettingsDialog(tabId: string): void {
+    this.showSettingsModal(tabId);
+  }
+
+  private showSettingsModal(tabId: string | null): void {
+    const modal = document.getElementById("settings-modal")!;
+    const titleEl = modal.querySelector(".modal-title") as HTMLElement;
+    const nameInput = document.getElementById(
+      "settings-name",
+    ) as HTMLInputElement;
+    const cmdInput = document.getElementById(
+      "settings-command",
+    ) as HTMLInputElement;
+    const argsInput = document.getElementById(
+      "settings-args",
+    ) as HTMLInputElement;
+    const cwdInput = document.getElementById(
+      "settings-cwd",
+    ) as HTMLInputElement;
+    const kindSelect = document.getElementById(
+      "settings-cli-kind",
+    ) as HTMLSelectElement;
+
+    if (tabId) {
+      const state = this.tabs.get(tabId);
+      if (!state) return;
+      titleEl.textContent = "Tab Settings";
+      nameInput.value = state.config.name;
+      cmdInput.value = state.config.command;
+      argsInput.value = state.config.args.join(", ");
+      cwdInput.value = state.config.cwd ?? "";
+      kindSelect.value = state.config.cli_kind;
+    } else {
+      titleEl.textContent = "New Agent Tab";
+      nameInput.value = "";
+      cmdInput.value = "";
+      argsInput.value = "";
+      cwdInput.value = "";
+      kindSelect.value = "claude";
+    }
+
+    modal.dataset.editTabId = tabId ?? "";
+    modal.style.display = "flex";
+    nameInput.focus();
+  }
+
+  /** Called from main when the modal save button is clicked. */
+  saveFromModal(): void {
+    const modal = document.getElementById("settings-modal")!;
+    const editTabId = modal.dataset.editTabId || null;
+
+    const nameInput = document.getElementById(
+      "settings-name",
+    ) as HTMLInputElement;
+    const cmdInput = document.getElementById(
+      "settings-command",
+    ) as HTMLInputElement;
+    const argsInput = document.getElementById(
+      "settings-args",
+    ) as HTMLInputElement;
+    const cwdInput = document.getElementById(
+      "settings-cwd",
+    ) as HTMLInputElement;
+    const kindSelect = document.getElementById(
+      "settings-cli-kind",
+    ) as HTMLSelectElement;
+
+    const name = nameInput.value.trim() || "Untitled";
+    const command = cmdInput.value.trim();
+    const args = argsInput.value
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const cwd = cwdInput.value.trim() || null;
+    const cli_kind = kindSelect.value;
+
+    if (!command) return;
+
+    if (editTabId) {
+      // Update existing tab
+      const state = this.tabs.get(editTabId);
+      if (state) {
+        state.config.name = name;
+        state.config.command = command;
+        state.config.args = args;
+        state.config.cwd = cwd;
+        state.config.cli_kind = cli_kind;
+        // Update tab label
+        const nameSpan = state.tabEl.querySelector(".tab-name");
+        if (nameSpan) nameSpan.textContent = name;
+        // Update toolbar if active
+        if (this.activeTabId === editTabId) {
+          this.updateToolbar(state);
+        }
+      }
+    } else {
+      // Create new tab
+      const id = `tab-${this.nextTabNum++}`;
+      this.createTab({ id, name, command, args, cwd, cli_kind }, true);
+    }
+
+    modal.style.display = "none";
+    this.persistConfig();
+  }
+
+  // -----------------------------------------------------------------------
+  // Persistence
+  // -----------------------------------------------------------------------
+
+  private persistConfig(): void {
+    if (this.onConfigChange) {
+      this.onConfigChange(this.getConfig());
+    }
+  }
+}


### PR DESCRIPTION
Refs #23

2ペイン固定レイアウトをタブベースUIに移行し、エージェント種別タブで切り替え可能にした。

- AppConfig を left/right から tabs[] 配列に移行（レガシー設定の自動マイグレーション付き）
- TabManager コンポーネント新規作成（タブ追加・切替・閉じ・ドラッグ並べ替え）
- 各タブが独立した ChatPane + PTY 接続を保持、タブ切り替え時は DOM show/hide で表示差替
- 「+」ボタンで新規エージェントタブ追加（CLI コマンド設定ダイアログ）
- CLI Kind 選択（Claude / Codex / Gemini）をモーダルに追加