### PR TITLE
feat(ui): add session sidebar with create/switch/persist

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -18,6 +18,31 @@ pub struct AppConfig {
     pub tabs: Vec<TabConfig>,
 }
 
+// ---------------------------------------------------------------------------
+// Session persistence types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedChatMessage {
+    pub role: String,
+    pub content_type: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionData {
+    pub id: String,
+    pub name: String,
+    pub messages: Vec<SavedChatMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabSessions {
+    pub tab_id: String,
+    pub active_session_id: Option<String>,
+    pub sessions: Vec<SessionData>,
+}
+
 /// Legacy config format for migration
 #[derive(Debug, Clone, Deserialize)]
 struct LegacyPaneConfig {
@@ -130,4 +155,39 @@ pub fn save_config(app: AppHandle, config: AppConfig) -> Result<(), String> {
     let content = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config: {e}"))?;
     std::fs::write(&path, content).map_err(|e| format!("Failed to write config: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Session persistence commands
+// ---------------------------------------------------------------------------
+
+fn sessions_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
+    Ok(dir.join("sessions.json"))
+}
+
+#[tauri::command]
+pub fn save_sessions(app: AppHandle, data: Vec<TabSessions>) -> Result<(), String> {
+    let path = sessions_path(&app)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create sessions dir: {e}"))?;
+    }
+    let content = serde_json::to_string_pretty(&data)
+        .map_err(|e| format!("Failed to serialize sessions: {e}"))?;
+    std::fs::write(&path, content).map_err(|e| format!("Failed to write sessions: {e}"))
+}
+
+#[tauri::command]
+pub fn load_sessions(app: AppHandle) -> Result<Vec<TabSessions>, String> {
+    let path = sessions_path(&app)?;
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let content =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read sessions: {e}"))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse sessions: {e}"))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,8 @@ pub fn run() {
             pty::kill_pty,
             config::load_config,
             config::save_config,
+            config::save_sessions,
+            config::load_sessions,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -20,6 +20,13 @@ interface ChatMessage {
 // ChatPane — one chat UI instance
 // ---------------------------------------------------------------------------
 
+/** Serializable message for persistence. */
+export interface SavedChatMessage {
+  role: Role;
+  content_type: ContentType;
+  body: string;
+}
+
 export class ChatPane {
   private container: HTMLElement;
   private messagesEl: HTMLElement;
@@ -28,6 +35,8 @@ export class ChatPane {
   private ptyId: string | null = null;
   private unlistenChat: UnlistenFn | null = null;
   private unlistenExit: UnlistenFn | null = null;
+  /** Callback when user sends a message (for auto-naming). */
+  onUserMessage: ((text: string) => void) | null = null;
   /** Whether user has scrolled up (disables auto-scroll) */
   private userScrolled = false;
   /** Element for the currently streaming assistant message (appended incrementally) */
@@ -36,6 +45,9 @@ export class ChatPane {
   private streamingBody = "";
   /** Content type of the current streaming message */
   private streamingType: ContentType | null = null;
+  /** Message history for persistence (capped at MAX_MESSAGES) */
+  private messageHistory: SavedChatMessage[] = [];
+  private static readonly MAX_MESSAGES = 1000;
 
   /**
    * @param containerOrId - Either an HTMLElement to use as the container,
@@ -148,12 +160,13 @@ export class ChatPane {
     }
   }
 
-  /** Clear all messages. */
+  /** Clear all messages and history. */
   clear(): void {
     this.messagesEl.innerHTML = "";
     this.streamingBubble = null;
     this.streamingBody = "";
     this.streamingType = null;
+    this.messageHistory = [];
   }
 
   /** Show an informational banner (e.g. welcome text). */
@@ -168,6 +181,36 @@ export class ChatPane {
   /** Get the current PTY id (null if not attached). */
   getPtyId(): string | null {
     return this.ptyId;
+  }
+
+  /** Get accumulated message history for persistence. */
+  getMessages(): SavedChatMessage[] {
+    return [...this.messageHistory];
+  }
+
+  /** Restore messages from persistence — rebuilds the DOM. */
+  setMessages(msgs: SavedChatMessage[]): void {
+    this.clear();
+    this.messageHistory = msgs.slice(-ChatPane.MAX_MESSAGES);
+    for (const m of this.messageHistory) {
+      const msg: ChatMessage = { role: m.role, content_type: m.content_type, body: m.body };
+      switch (msg.content_type) {
+        case "tool_use":
+          this.appendToolUse(msg);
+          break;
+        case "tool_result":
+          this.appendToolResult(msg);
+          break;
+        case "status":
+          this.appendStatusBanner(msg.body);
+          break;
+        default:
+          this.appendBubble(msg);
+      }
+    }
+    // Scroll to bottom after restore
+    this.userScrolled = false;
+    this.scrollToBottom();
   }
 
   // -----------------------------------------------------------------------
@@ -200,6 +243,8 @@ export class ChatPane {
     // Non-streaming message — finalize any ongoing stream first
     this.finalizeStreaming();
 
+    this.pushHistory({ role: msg.role, content_type: msg.content_type, body: msg.body });
+
     switch (msg.content_type) {
       case "tool_use":
         this.appendToolUse(msg);
@@ -216,9 +261,10 @@ export class ChatPane {
   }
 
   private finalizeStreaming(): void {
-    if (this.streamingBubble) {
+    if (this.streamingBubble && this.streamingType && this.streamingBody) {
       // Final render with complete body
       this.updateStreamingBubble();
+      this.pushHistory({ role: "assistant", content_type: this.streamingType, body: this.streamingBody });
     }
     this.streamingBubble = null;
     this.streamingBody = "";
@@ -327,11 +373,13 @@ export class ChatPane {
     if (!text || !this.ptyId) return;
 
     // Display user message as a bubble
-    this.appendBubble({
-      role: "user",
-      content_type: "text",
-      body: text,
-    });
+    const userMsg: ChatMessage = { role: "user", content_type: "text", body: text };
+    this.pushHistory({ role: "user", content_type: "text", body: text });
+    this.appendBubble(userMsg);
+
+    if (this.onUserMessage) {
+      this.onUserMessage(text);
+    }
 
     // Send to PTY stdin as a line
     try {
@@ -342,6 +390,17 @@ export class ChatPane {
 
     this.textareaEl.value = "";
     this.textareaEl.style.height = "auto";
+  }
+
+  // -----------------------------------------------------------------------
+  // History tracking
+  // -----------------------------------------------------------------------
+
+  private pushHistory(msg: SavedChatMessage): void {
+    this.messageHistory.push(msg);
+    if (this.messageHistory.length > ChatPane.MAX_MESSAGES) {
+      this.messageHistory = this.messageHistory.slice(-ChatPane.MAX_MESSAGES);
+    }
   }
 
   // -----------------------------------------------------------------------

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import "./styles.css";
 import { TabManager, AppConfig } from "./tabs";
+import { saveAllSessions } from "./sessions";
 import { invoke } from "@tauri-apps/api/core";
 
 function closeSettingsModal() {
@@ -20,6 +21,15 @@ window.addEventListener("DOMContentLoaded", async () => {
     } catch (e) {
       console.error("Failed to save config:", e);
     }
+  };
+
+  // Persist sessions on change (debounced)
+  let sessionSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  manager.onSessionsChange = () => {
+    if (sessionSaveTimer) clearTimeout(sessionSaveTimer);
+    sessionSaveTimer = setTimeout(() => {
+      saveAllSessions(manager.getSessionManagers());
+    }, 500);
   };
 
   // Load persisted config (falls back to defaults on first run)
@@ -50,7 +60,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     };
   }
 
-  manager.loadTabs(appConfig);
+  await manager.loadTabs(appConfig);
 
   // Modal button handlers
   document

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,0 +1,349 @@
+import { ChatPane, SavedChatMessage } from "./chat";
+import { invoke } from "@tauri-apps/api/core";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors Rust TabSessions / SessionData
+// ---------------------------------------------------------------------------
+
+export interface SessionData {
+  id: string;
+  name: string;
+  messages: SavedChatMessage[];
+}
+
+export interface TabSessions {
+  tab_id: string;
+  active_session_id: string | null;
+  sessions: SessionData[];
+}
+
+// ---------------------------------------------------------------------------
+// SessionManager — sidebar UI + session CRUD for one tab
+// ---------------------------------------------------------------------------
+
+export class SessionManager {
+  private tabId: string;
+  private sessions: SessionData[] = [];
+  private activeSessionId: string | null = null;
+  private chatPane: ChatPane;
+  private sidebarEl: HTMLElement;
+  private listEl: HTMLElement;
+  private collapsed = false;
+  private nextSessionNum = 1;
+
+  /** Callback when sessions change (for persistence). */
+  onSessionsChange: (() => void) | null = null;
+
+  constructor(tabId: string, chatPane: ChatPane, parentEl: HTMLElement) {
+    this.tabId = tabId;
+    this.chatPane = chatPane;
+
+    // Build sidebar DOM
+    this.sidebarEl = document.createElement("div");
+    this.sidebarEl.className = "session-sidebar";
+
+    const header = document.createElement("div");
+    header.className = "session-sidebar-header";
+
+    const toggleBtn = document.createElement("button");
+    toggleBtn.className = "session-toggle-btn";
+    toggleBtn.innerHTML = "&#9776;";
+    toggleBtn.title = "Toggle sidebar";
+    toggleBtn.addEventListener("click", () => this.toggleSidebar());
+
+    const title = document.createElement("span");
+    title.className = "session-sidebar-title";
+    title.textContent = "Sessions";
+
+    const newBtn = document.createElement("button");
+    newBtn.className = "session-new-btn";
+    newBtn.textContent = "+";
+    newBtn.title = "New session";
+    newBtn.addEventListener("click", () => this.createSession());
+
+    header.appendChild(toggleBtn);
+    header.appendChild(title);
+    header.appendChild(newBtn);
+
+    this.listEl = document.createElement("div");
+    this.listEl.className = "session-list";
+
+    this.sidebarEl.appendChild(header);
+    this.sidebarEl.appendChild(this.listEl);
+
+    // Insert sidebar as the first child of the parent container
+    parentEl.insertBefore(this.sidebarEl, parentEl.firstChild);
+
+    // Auto-name session from first user message
+    this.chatPane.onUserMessage = (text: string) => {
+      this.autoNameFromFirstMessage(text);
+      this.notifyChange();
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /** Get the sidebar element (for external layout). */
+  getElement(): HTMLElement {
+    return this.sidebarEl;
+  }
+
+  /** Export session data for persistence. */
+  exportData(): TabSessions {
+    // Save current chat state into the active session before export
+    this.saveCurrent();
+    return {
+      tab_id: this.tabId,
+      active_session_id: this.activeSessionId,
+      sessions: this.sessions.map((s) => ({ ...s, messages: [...s.messages] })),
+    };
+  }
+
+  /** Import session data from persistence. */
+  importData(data: TabSessions): void {
+    this.sessions = data.sessions;
+    this.activeSessionId = data.active_session_id;
+
+    // Track next session number
+    const nums = this.sessions
+      .map((s) => {
+        const m = s.id.match(/^session-(\d+)$/);
+        return m ? parseInt(m[1], 10) : 0;
+      })
+      .filter((n) => n > 0);
+    this.nextSessionNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
+
+    this.renderList();
+
+    // Restore active session's messages
+    if (this.activeSessionId) {
+      const session = this.sessions.find((s) => s.id === this.activeSessionId);
+      if (session) {
+        this.chatPane.setMessages(session.messages);
+      }
+    }
+  }
+
+  /** Create a default session if none exist. */
+  ensureDefaultSession(): void {
+    if (this.sessions.length === 0) {
+      this.createSession();
+    }
+  }
+
+  /** Get the active session ID. */
+  getActiveSessionId(): string | null {
+    return this.activeSessionId;
+  }
+
+  // -----------------------------------------------------------------------
+  // Session lifecycle
+  // -----------------------------------------------------------------------
+
+  createSession(name?: string): void {
+    const id = `session-${this.nextSessionNum++}`;
+    const sessionName = name || `Session ${this.sessions.length + 1}`;
+    const session: SessionData = { id, name: sessionName, messages: [] };
+
+    // Save current session's messages before switching
+    this.saveCurrent();
+
+    this.sessions.push(session);
+    this.switchTo(id);
+    this.renderList();
+    this.notifyChange();
+  }
+
+  private switchTo(sessionId: string): void {
+    // Save current session before switching
+    this.saveCurrent();
+
+    const session = this.sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+
+    this.activeSessionId = sessionId;
+    this.chatPane.setMessages(session.messages);
+    this.renderList();
+  }
+
+  private deleteSession(sessionId: string): void {
+    const idx = this.sessions.findIndex((s) => s.id === sessionId);
+    if (idx < 0) return;
+
+    this.sessions.splice(idx, 1);
+
+    if (this.activeSessionId === sessionId) {
+      // Switch to the nearest session or create a new one
+      if (this.sessions.length > 0) {
+        const newIdx = Math.min(idx, this.sessions.length - 1);
+        this.activeSessionId = null; // prevent saveCurrent
+        this.switchTo(this.sessions[newIdx].id);
+      } else {
+        this.activeSessionId = null;
+        this.chatPane.clear();
+        this.createSession();
+        return;
+      }
+    }
+
+    this.renderList();
+    this.notifyChange();
+  }
+
+  private renameSession(sessionId: string, newName: string): void {
+    const session = this.sessions.find((s) => s.id === sessionId);
+    if (session) {
+      session.name = newName.trim() || session.name;
+      this.renderList();
+      this.notifyChange();
+    }
+  }
+
+  /** Auto-generate session name from the first user message. */
+  autoNameFromFirstMessage(text: string): void {
+    if (!this.activeSessionId) return;
+    const session = this.sessions.find((s) => s.id === this.activeSessionId);
+    if (!session) return;
+    // Only auto-name if the name is still the default pattern
+    if (/^Session \d+$/.test(session.name)) {
+      const truncated = text.length > 40 ? text.slice(0, 40) + "..." : text;
+      session.name = truncated;
+      this.renderList();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  private saveCurrent(): void {
+    if (!this.activeSessionId) return;
+    const session = this.sessions.find((s) => s.id === this.activeSessionId);
+    if (session) {
+      session.messages = this.chatPane.getMessages();
+    }
+  }
+
+  private toggleSidebar(): void {
+    this.collapsed = !this.collapsed;
+    this.sidebarEl.classList.toggle("session-sidebar-collapsed", this.collapsed);
+  }
+
+  private notifyChange(): void {
+    if (this.onSessionsChange) {
+      this.onSessionsChange();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  private renderList(): void {
+    this.listEl.innerHTML = "";
+
+    for (const session of this.sessions) {
+      const item = document.createElement("div");
+      item.className = "session-item";
+      if (session.id === this.activeSessionId) {
+        item.classList.add("session-active");
+      }
+
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "session-name";
+      nameSpan.textContent = session.name;
+      nameSpan.title = session.name;
+
+      // Double-click to rename
+      nameSpan.addEventListener("dblclick", (e) => {
+        e.stopPropagation();
+        this.startRename(session.id, nameSpan);
+      });
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.className = "session-delete-btn";
+      deleteBtn.textContent = "\u00d7";
+      deleteBtn.title = "Delete session";
+      deleteBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.deleteSession(session.id);
+      });
+
+      item.appendChild(nameSpan);
+      item.appendChild(deleteBtn);
+
+      item.addEventListener("click", () => {
+        if (session.id !== this.activeSessionId) {
+          this.switchTo(session.id);
+          this.notifyChange();
+        }
+      });
+
+      this.listEl.appendChild(item);
+    }
+  }
+
+  private startRename(sessionId: string, nameSpan: HTMLElement): void {
+    const session = this.sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+
+    const input = document.createElement("input");
+    input.className = "session-rename-input";
+    input.type = "text";
+    input.value = session.name;
+
+    const commit = () => {
+      const newName = input.value.trim();
+      if (newName) {
+        this.renameSession(sessionId, newName);
+      } else {
+        this.renderList();
+      }
+    };
+
+    input.addEventListener("blur", commit);
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        input.blur();
+      }
+      if (e.key === "Escape") {
+        input.removeEventListener("blur", commit);
+        this.renderList();
+      }
+    });
+
+    nameSpan.replaceWith(input);
+    input.focus();
+    input.select();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Persistence helpers
+// ---------------------------------------------------------------------------
+
+export async function saveAllSessions(
+  managers: Map<string, SessionManager>,
+): Promise<void> {
+  const data: TabSessions[] = [];
+  for (const [, mgr] of managers) {
+    data.push(mgr.exportData());
+  }
+  try {
+    await invoke("save_sessions", { data });
+  } catch (e) {
+    console.error("Failed to save sessions:", e);
+  }
+}
+
+export async function loadAllSessions(): Promise<TabSessions[]> {
+  try {
+    return await invoke<TabSessions[]>("load_sessions");
+  } catch (e) {
+    console.error("Failed to load sessions:", e);
+    return [];
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -261,9 +261,173 @@
 .tab-content {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   background: #0a0a1a;
   overflow: hidden;
+}
+
+.tab-chat-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ----------------------------------------------------------------
+   Session sidebar
+   ---------------------------------------------------------------- */
+
+.session-sidebar {
+  width: 250px;
+  min-width: 250px;
+  display: flex;
+  flex-direction: column;
+  background: #12122a;
+  border-right: 1px solid #0f3460;
+  overflow: hidden;
+  transition: width 0.2s, min-width 0.2s;
+}
+
+.session-sidebar-collapsed {
+  width: 0;
+  min-width: 0;
+  border-right: none;
+}
+
+.session-sidebar-collapsed .session-sidebar-header {
+  /* Keep header visible via absolute positioning when collapsed */
+}
+
+.session-sidebar-collapsed .session-list,
+.session-sidebar-collapsed .session-sidebar-title,
+.session-sidebar-collapsed .session-new-btn {
+  display: none;
+}
+
+.session-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid #0f3460;
+  flex-shrink: 0;
+}
+
+.session-toggle-btn {
+  background: none;
+  border: none;
+  color: #a8b2d1;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 2px 4px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.session-toggle-btn:hover {
+  color: #64ffda;
+}
+
+.session-sidebar-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #a8b2d1;
+  flex: 1;
+}
+
+.session-new-btn {
+  background: none;
+  border: 1px solid #0f3460;
+  border-radius: 4px;
+  color: #64ffda;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 0 6px;
+  line-height: 1.4;
+  transition: all 0.15s;
+}
+
+.session-new-btn:hover {
+  background: #0f3460;
+}
+
+.session-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.session-list::-webkit-scrollbar {
+  width: 4px;
+}
+.session-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+.session-list::-webkit-scrollbar-thumb {
+  background: #0f3460;
+  border-radius: 2px;
+}
+
+.session-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.session-item:hover {
+  background: #1a1a3a;
+}
+
+.session-item.session-active {
+  background: #0f3460;
+  border-left: 2px solid #64ffda;
+}
+
+.session-name {
+  flex: 1;
+  font-size: 12px;
+  color: #a8b2d1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-active .session-name {
+  color: #e0e0e0;
+}
+
+.session-delete-btn {
+  background: none;
+  border: none;
+  color: #4a5568;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.session-item:hover .session-delete-btn {
+  opacity: 1;
+}
+
+.session-delete-btn:hover {
+  color: #f87171;
+}
+
+.session-rename-input {
+  flex: 1;
+  background: #0a0a1a;
+  border: 1px solid #64ffda;
+  border-radius: 3px;
+  color: #e0e0e0;
+  font-size: 12px;
+  padding: 2px 6px;
+  outline: none;
 }
 
 /* ----------------------------------------------------------------

--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -1,4 +1,5 @@
 import { ChatPane } from "./chat";
+import { SessionManager, loadAllSessions } from "./sessions";
 import { invoke } from "@tauri-apps/api/core";
 
 // ---------------------------------------------------------------------------
@@ -27,6 +28,7 @@ export type AgentStatus = "stopped" | "running" | "error";
 interface TabState {
   config: TabConfig;
   chat: ChatPane;
+  sessionMgr: SessionManager;
   containerEl: HTMLElement;
   tabEl: HTMLElement;
   status: AgentStatus;
@@ -42,9 +44,12 @@ export class TabManager {
   private tabBarEl: HTMLElement;
   private contentAreaEl: HTMLElement;
   private nextTabNum = 1;
+  private sessionManagers: Map<string, SessionManager> = new Map();
 
   /** Callback when config changes (for persistence). */
   onConfigChange: ((config: AppConfig) => void) | null = null;
+  /** Callback when session data changes (for persistence). */
+  onSessionsChange: (() => void) | null = null;
 
   constructor(tabBarEl: HTMLElement, contentAreaEl: HTMLElement) {
     this.tabBarEl = tabBarEl;
@@ -63,8 +68,8 @@ export class TabManager {
   // Public API
   // -----------------------------------------------------------------------
 
-  /** Load tabs from persisted config. */
-  loadTabs(config: AppConfig): void {
+  /** Load tabs from persisted config, then restore sessions. */
+  async loadTabs(config: AppConfig): Promise<void> {
     for (const tabCfg of config.tabs) {
       this.createTab(tabCfg, false);
     }
@@ -80,6 +85,25 @@ export class TabManager {
       })
       .filter((n) => n > 0);
     this.nextTabNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
+
+    // Restore session data
+    const allSessions = await loadAllSessions();
+    for (const tabSessions of allSessions) {
+      const mgr = this.sessionManagers.get(tabSessions.tab_id);
+      if (mgr) {
+        mgr.importData(tabSessions);
+      }
+    }
+
+    // Ensure each tab has at least one session
+    for (const [, mgr] of this.sessionManagers) {
+      mgr.ensureDefaultSession();
+    }
+  }
+
+  /** Get all session managers (for persistence). */
+  getSessionManagers(): Map<string, SessionManager> {
+    return this.sessionManagers;
   }
 
   /** Get the current config for persistence. */
@@ -152,18 +176,32 @@ export class TabManager {
   // -----------------------------------------------------------------------
 
   private createTab(cfg: TabConfig, activate: boolean): void {
-    // Chat container (hidden by default)
+    // Tab content wrapper (hidden by default) — flex row for sidebar + chat
     const containerEl = document.createElement("div");
     containerEl.className = "tab-content";
     containerEl.dataset.tabId = cfg.id;
     containerEl.style.display = "none";
     this.contentAreaEl.appendChild(containerEl);
 
-    // ChatPane builds its DOM inside the container
-    const chat = new ChatPane(containerEl);
+    // Chat area (right side of the flex row)
+    const chatArea = document.createElement("div");
+    chatArea.className = "tab-chat-area";
+    containerEl.appendChild(chatArea);
+
+    // ChatPane builds its DOM inside the chat area
+    const chat = new ChatPane(chatArea);
     chat.appendStatusBanner(
       `Li+ Desktop \u2014 ${cfg.name} tab. Press Start to launch.`,
     );
+
+    // SessionManager builds sidebar and inserts it before chatArea in the container
+    const sessionMgr = new SessionManager(cfg.id, chat, containerEl);
+    sessionMgr.onSessionsChange = () => {
+      if (this.onSessionsChange) {
+        this.onSessionsChange();
+      }
+    };
+    this.sessionManagers.set(cfg.id, sessionMgr);
 
     // Tab bar item
     const tabEl = document.createElement("div");
@@ -229,6 +267,7 @@ export class TabManager {
     this.tabs.set(cfg.id, {
       config: cfg,
       chat,
+      sessionMgr,
       containerEl,
       tabEl,
       status: "stopped",
@@ -276,10 +315,11 @@ export class TabManager {
       state.chat.detach();
     }
 
-    // Remove DOM
+    // Remove DOM and session manager
     state.tabEl.remove();
     state.containerEl.remove();
     this.tabs.delete(tabId);
+    this.sessionManagers.delete(tabId);
 
     // If the closed tab was active, switch to the first remaining
     if (this.activeTabId === tabId) {


### PR DESCRIPTION
Refs #24

各エージェントタブ内にセッション一覧サイドバーを追加し、複数セッション（スレッド）の作成・切り替え・永続化を実装。

- セッションサイドバー（250px固定幅、折りたたみ可能）をタブコンテンツ左側に配置
- 「+ New Session」ボタンによるセッション作成、クリックで切り替え、ダブルクリックでリネーム、削除対応
- 最初のユーザー入力からセッション名を自動生成
- チャット履歴を Tauri app data dir に JSON で永続化（1セッションあたり最大1000メッセージ）
- アプリ再起動時にセッション一覧とメッセージ履歴を復元
- Rust バックエンド: save_sessions / load_sessions Tauri コマンド追加