### PR TITLE
fix(codex): implement pipe-based per-message process model for Codex CLI

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             pty::spawn_pty,
             pty::spawn_stream_pty,
+            pty::spawn_stream_pipe,
             pty::write_pty,
             pty::resize_pty,
             pty::kill_pty,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -395,3 +395,117 @@ pub fn spawn_stream_pty(
 
     Ok(id)
 }
+
+/// Spawn a CLI process in pipe mode for non-interactive CLIs (e.g. Codex exec).
+///
+/// Uses stdin/stdout pipes (no PTY). Reads stdout line-by-line, parses NDJSON,
+/// and emits `chat-message-{id}` Tauri events. Stdin is closed immediately
+/// (Codex exec takes the prompt via CLI args, not stdin).
+#[tauri::command]
+pub fn spawn_stream_pipe(
+    app: AppHandle,
+    state: tauri::State<PtyState>,
+    command: String,
+    args: Vec<String>,
+    cwd: Option<String>,
+    cli_kind: String,
+) -> Result<String, String> {
+    let kind = match cli_kind.as_str() {
+        "claude" => CliKind::ClaudeCode,
+        "codex" => CliKind::Codex,
+        other => {
+            return Err(format!(
+                "Unknown cli_kind: {other}. Expected 'claude' or 'codex'."
+            ))
+        }
+    };
+
+    let mut cmd = if cfg!(windows) {
+        let mut c = std::process::Command::new("cmd.exe");
+        c.arg("/C");
+        c.arg(&command);
+        for arg in &args {
+            c.arg(arg);
+        }
+        c
+    } else {
+        let mut c = std::process::Command::new(&command);
+        for arg in &args {
+            c.arg(arg);
+        }
+        c
+    };
+
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn '{command}': {e}"))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture stdout".to_string())?;
+
+    let id = Uuid::new_v4().to_string();
+    let id_clone = id.clone();
+    let id_clone2 = id.clone();
+    let app_clone = app.clone();
+
+    state.procs.lock().insert(
+        id.clone(),
+        ProcessInstance::Pipe(PipeInstance {
+            stdin: child.stdin.take().unwrap_or_else(|| {
+                // stdin was set to null; create a placeholder that will never be used.
+                // PipeInstance requires a ChildStdin field for write_pty compatibility.
+                std::process::Command::new(if cfg!(windows) { "cmd.exe" } else { "true" })
+                    .stdin(std::process::Stdio::piped())
+                    .stdout(std::process::Stdio::null())
+                    .spawn()
+                    .expect("placeholder stdin spawn")
+                    .stdin
+                    .take()
+                    .expect("placeholder stdin")
+            }),
+            child,
+        }),
+    );
+
+    // Background reader thread: line-by-line NDJSON parsing
+    let procs_clone = Arc::clone(&state.procs);
+    std::thread::spawn(move || {
+        let buf_reader = BufReader::new(stdout);
+        for line in buf_reader.lines() {
+            match line {
+                Ok(text) => {
+                    if let Some(value) = stream_parser::parse_ndjson_line(&text) {
+                        if let Some(msg) = stream_parser::convert(kind, &value) {
+                            let _ = app_clone.emit(&format!("chat-message-{}", id_clone), &msg);
+                        }
+                        let _ = app_clone.emit(&format!("stream-raw-{}", id_clone), &value);
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+
+        // Collect exit code
+        let exit_code: Option<u32> = {
+            let mut map = procs_clone.lock();
+            if let Some(ProcessInstance::Pipe(pipe)) = map.get_mut(&id_clone2) {
+                pipe.child.wait().ok().map(|s| s.code().unwrap_or(1) as u32)
+            } else {
+                None
+            }
+        };
+        let _ = app_clone.emit(&format!("pty-exit-{}", id_clone2), exit_code);
+    });
+
+    Ok(id)
+}

--- a/src-tauri/src/stream_parser.rs
+++ b/src-tauri/src/stream_parser.rs
@@ -449,6 +449,13 @@ fn convert_codex(v: &Value) -> Option<ChatMessage> {
 /// Extract text from a Codex item's content field.
 /// Content can be a string or an array of { type: "text", text: "..." } objects.
 fn extract_codex_text(item: &Value) -> String {
+    // Try top-level "text" field first (v0.118.0+ uses this for agent_message)
+    if let Some(s) = item.get("text").and_then(|t| t.as_str()) {
+        if !s.is_empty() {
+            return s.to_string();
+        }
+    }
+    // Fall back to "content" field (array of {type,text} or plain string)
     if let Some(content) = item.get("content") {
         if let Some(s) = content.as_str() {
             return s.to_string();

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -37,6 +37,8 @@ export class ChatPane {
   private unlistenExit: UnlistenFn | null = null;
   /** Callback when user sends a message (for auto-naming). */
   onUserMessage: ((text: string) => void) | null = null;
+  /** Callback for Codex per-message send (set by TabManager). */
+  onCodexSend: ((prompt: string) => Promise<void>) | null = null;
   /** Whether user has scrolled up (disables auto-scroll) */
   private userScrolled = false;
   /** Element for the currently streaming assistant message (appended incrementally) */
@@ -374,7 +376,21 @@ export class ChatPane {
 
   private async sendMessage(): Promise<void> {
     const text = this.textareaEl.value.trim();
-    if (!text || !this.ptyId) return;
+    if (!text) return;
+
+    // Codex per-message mode: delegate to the callback (no persistent ptyId needed)
+    if (this.onCodexSend) {
+      const userMsg: ChatMessage = { role: "user", content_type: "text", body: text };
+      this.pushHistory({ role: "user", content_type: "text", body: text });
+      this.appendBubble(userMsg);
+      if (this.onUserMessage) this.onUserMessage(text);
+      this.textareaEl.value = "";
+      this.textareaEl.style.height = "auto";
+      await this.onCodexSend(text);
+      return;
+    }
+
+    if (!this.ptyId) return;
 
     // Display user message as a bubble
     const userMsg: ChatMessage = { role: "user", content_type: "text", body: text };

--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -132,18 +132,41 @@ export class TabManager {
 
     const { command, args, cwd, cli_kind } = state.config;
 
-    // Inject stream-json flags based on CLI kind
-    let streamArgs: string[];
-    if (cli_kind === "claude") {
-      streamArgs = ["--output-format", "stream-json", "--input-format", "stream-json", "--verbose", ...args];
-    } else if (cli_kind === "codex") {
-      streamArgs = ["exec", "--json", ...args];
-    } else {
-      streamArgs = [...args];
+    state.chat.clear();
+
+    if (cli_kind === "codex") {
+      // Codex: message-per-process model.
+      // Don't start a process now — wait for the user to send a message.
+      state.chat.appendStatusBanner(`Li+ Desktop — ${state.config.name}. Type a message to start.`);
+      this.setStatus(tabId, "stopped");
+      // Wire up the per-message handler
+      state.chat.onCodexSend = async (prompt: string) => {
+        state.chat.appendStatusBanner("Running...");
+        this.setStatus(tabId, "running");
+        try {
+          const execArgs = ["exec", "--json", "--full-auto", "--skip-git-repo-check", ...args, prompt];
+          const id = await invoke<string>("spawn_stream_pipe", {
+            command,
+            args: execArgs,
+            cwd: cwd ?? null,
+            cliKind: cli_kind,
+          });
+          await state.chat.attach(id, () => {
+            this.setStatus(tabId, "stopped");
+          });
+        } catch (e) {
+          state.chat.appendStatusBanner(`Failed: ${e}`);
+          this.setStatus(tabId, "error");
+        }
+      };
+      return;
     }
 
-    state.chat.clear();
+    // Claude Code: persistent session via PTY + stream-json
+    const streamArgs = ["--output-format", "stream-json", "--input-format", "stream-json", "--verbose", ...args];
+
     state.chat.appendStatusBanner(`Starting ${command}...`);
+    state.chat.onCodexSend = null;
 
     try {
       const id = await invoke<string>("spawn_stream_pty", {


### PR DESCRIPTION
Refs #35

Codex CLI (codex exec) はワンショット実行モデルのため、Claude Code の双方向 stream-json stdin とは互換性がなかった。メッセージごとに新規パイププロセスを起動する `spawn_stream_pipe` を追加し、`exec --json --full-auto` で JSONL イベントストリームを正しく受信できるようにした。

変更点:
- `stream_parser.rs`: `extract_codex_text()` で `item.text` フィールドを優先チェック
- `pty.rs`: `spawn_stream_pipe` 関数追加（パイプベースプロセス起動）
- `lib.rs`: `spawn_stream_pipe` を invoke ハンドラに登録
- `tabs.ts`: Codex タブで `spawn_stream_pipe` + per-message モデルを使用
- `chat.ts`: `onCodexSend` コールバック追加