### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liplus-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liplus-desktop"
-version = "0.1.0"
+version = "0.2.0"
 description = "Multi-agent desktop for Li+ language"
 authors = ["Liplus Project Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "liplus-desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "org.liplus-project.liplus-desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Refs #51

v0.2.0 リリースのためバージョン番号を 0.1.0 → 0.2.0 に更新。

変更ファイル: package.json, Cargo.toml, tauri.conf.json