### PR TITLE
fix(pty): send plain text to PTY stdin instead of stream-json envelope

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -197,11 +197,14 @@ pub fn kill_pty(state: tauri::State<PtyState>, id: String) -> Result<(), String>
     Ok(())
 }
 
-/// Spawn a CLI process in stream-json mode using a real PTY.
+/// Spawn a CLI process in interactive PTY mode with NDJSON output parsing.
 ///
 /// Uses a PTY so the CLI detects a terminal and shows interactive prompts
-/// (trust confirmation, channel development warning, etc.). The reader thread
-/// operates in two phases:
+/// (trust confirmation, channel development warning, etc.). Output is parsed
+/// as NDJSON via `--output-format stream-json`. User input is sent as plain
+/// text + carriage return (interactive mode, no `--input-format`).
+///
+/// The reader thread operates in two phases:
 ///
 /// **Phase 1 (Init):** Read raw PTY output byte-by-byte, accumulating into a
 /// line buffer. Confirmation prompts from Ink UI are auto-accepted by sending
@@ -209,9 +212,8 @@ pub fn kill_pty(state: tauri::State<PtyState>, id: String) -> Result<(), String>
 /// transition to Phase 2.
 ///
 /// **Phase 2 (Stream):** Read line-by-line, strip ANSI escapes, parse NDJSON,
-/// and emit `chat-message-{id}` Tauri events — same as the old pipe mode.
-///
-/// User input is sent as stream-json via `write_pty`.
+/// and emit `chat-message-{id}` Tauri events. PTY echo lines (user input
+/// echoed back) are silently dropped as they fail JSON parsing.
 #[tauri::command]
 pub fn spawn_stream_pty(
     app: AppHandle,
@@ -361,6 +363,9 @@ pub fn spawn_stream_pty(
 
         // ── Phase 2: Stream NDJSON (or ANSI in interactive/Channel mode) ──
         // Wrap reader in BufReader for line-by-line reading.
+        // Note: PTY echo lines (user input echoed back by the terminal) are
+        // plain text and will fail JSON parsing in parse_ndjson_line, so they
+        // are silently dropped. No explicit filtering needed.
         let buf_reader = BufReader::new(reader);
         for line in buf_reader.lines() {
             match line {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -401,17 +401,10 @@ export class ChatPane {
       this.onUserMessage(text);
     }
 
-    // Send to stdin as stream-json formatted message
-    // Claude Code --input-format stream-json expects: {"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]}}
-    const streamMsg = JSON.stringify({
-      type: "user",
-      message: {
-        role: "user",
-        content: [{ type: "text", text }],
-      },
-    });
+    // Send plain text to PTY stdin (interactive mode — no stream-json input)
+    // The Ink UI receives this as keyboard input followed by Enter.
     try {
-      await invoke("write_pty", { id: this.ptyId, data: streamMsg + "\n" });
+      await invoke("write_pty", { id: this.ptyId, data: text + "\r" });
     } catch (e) {
       this.appendStatusBanner(`Send failed: ${e}`);
     }

--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -162,8 +162,10 @@ export class TabManager {
       return;
     }
 
-    // Claude Code: persistent session via PTY + stream-json
-    const streamArgs = ["--output-format", "stream-json", "--input-format", "stream-json", "--verbose", ...args];
+    // Claude Code: persistent session via PTY
+    // --output-format stream-json for NDJSON output parsing
+    // No --input-format: interactive PTY mode accepts plain text stdin
+    const streamArgs = ["--output-format", "stream-json", "--verbose", ...args];
 
     state.chat.appendStatusBanner(`Starting ${command}...`);
     state.chat.onCodexSend = null;


### PR DESCRIPTION
Refs #53

`--input-format stream-json` は `--print` モード専用のため、インタラクティブPTYモードではJSON入力が無視されユーザーメッセージがCLIに届かなかった。
プレーンテキスト + `\r` 送信に変更し、CLIのInk UIがキーボード入力として正しく受信できるようにした。