### PR TITLE
fix(tabs): prevent terminal fit on zero-dimension hidden containers

### DIFF
--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -261,8 +261,11 @@ export class TabManager {
     terminal.open(terminalContainerEl);
 
     // ResizeObserver to auto-fit terminal on container resize
+    // Guard against zero-dimension calls when tab is hidden (display:none)
     const resizeObserver = new ResizeObserver(() => {
-      fitAddon.fit();
+      if (terminalContainerEl.clientWidth > 0 && terminalContainerEl.clientHeight > 0) {
+        fitAddon.fit();
+      }
     });
     resizeObserver.observe(terminalContainerEl);
 
@@ -381,9 +384,10 @@ export class TabManager {
       this.activeTabId = tabId;
       this.updateToolbar(state);
       // Re-fit terminal after it becomes visible
-      setTimeout(() => {
+      // Use requestAnimationFrame to ensure layout is complete before fitting
+      requestAnimationFrame(() => {
         state.fitAddon.fit();
-      }, 50);
+      });
     }
   }
 


### PR DESCRIPTION
Refs #61

タブ非表示時に ResizeObserver が fit() を呼んでターミナルのカラム数が極小値になる問題を修正。
タブ切り替え時の fit() を requestAnimationFrame に変更し、レイアウト完了後に実行。