### PR TITLE
fix(ui): sidebar toggle and session switching

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -32,6 +32,9 @@ export class SessionManager {
   /** Callback when sessions change (for persistence). */
   onSessionsChange: (() => void) | null = null;
 
+  /** Callback when user switches to a different session. */
+  onSessionSwitch: ((sessionId: string) => void) | null = null;
+
   constructor(tabId: string, parentEl: HTMLElement) {
     this.tabId = tabId;
 
@@ -140,6 +143,11 @@ export class SessionManager {
 
     this.activeSessionId = sessionId;
     this.renderList();
+
+    // Notify tab manager to restart PTY for the new session
+    if (this.onSessionSwitch) {
+      this.onSessionSwitch(sessionId);
+    }
   }
 
   private deleteSession(sessionId: string): void {

--- a/src/styles.css
+++ b/src/styles.css
@@ -291,13 +291,8 @@
 }
 
 .session-sidebar-collapsed {
-  width: 0;
-  min-width: 0;
-  border-right: none;
-}
-
-.session-sidebar-collapsed .session-sidebar-header {
-  /* Keep header visible via absolute positioning when collapsed */
+  width: 40px;
+  min-width: 40px;
 }
 
 .session-sidebar-collapsed .session-list,

--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -255,6 +255,14 @@ export class TabManager {
         this.onSessionsChange();
       }
     };
+    sessionMgr.onSessionSwitch = (_sessionId: string) => {
+      // Restart PTY: stop current, clear terminal, start fresh
+      this.stopTab(cfg.id).then(() => {
+        const st = this.tabs.get(cfg.id);
+        if (st) st.terminal.clear();
+        this.startTab(cfg.id);
+      });
+    };
     this.sessionManagers.set(cfg.id, sessionMgr);
 
     // Open terminal into the container element


### PR DESCRIPTION
Refs #69

サイドバー折りたたみ: collapsed 時に min-width: 40px を維持してトグルボタンを残す。
セッション切り替え: switchTo に onSessionSwitch コールバックを追加、PTY 停止→クリア→再起動。